### PR TITLE
Companion kraken update to new order types

### DIFF
--- a/hummingbot/connector/exchange/kraken/kraken_auth.py
+++ b/hummingbot/connector/exchange/kraken/kraken_auth.py
@@ -3,6 +3,7 @@ import hashlib
 import hmac
 import json
 import time
+import urllib
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
@@ -20,10 +21,14 @@ class KrakenAuth(AuthBase):
         self.time_provider = time_provider
 
     @classmethod
-    def get_tracking_nonce(self) -> str:
-        nonce = int(time.time())
-        self._last_tracking_nonce = nonce if nonce > self._last_tracking_nonce else self._last_tracking_nonce + 1
-        return str(self._last_tracking_nonce)
+    def get_tracking_nonce(cls) -> str:
+        nonce = int(time.time() * 1000)
+        cls._last_tracking_nonce = (
+            nonce
+            if nonce > cls._last_tracking_nonce
+            else cls._last_tracking_nonce + 1
+        )
+        return str(cls._last_tracking_nonce)
 
     async def rest_authenticate(self, request: RESTRequest) -> RESTRequest:
 
@@ -54,11 +59,13 @@ class KrakenAuth(AuthBase):
         # Variables (API method, nonce, and POST data)
         api_path: bytes = bytes(uri, 'utf-8')
         api_nonce: str = self.get_tracking_nonce()
-        api_post: str = "nonce=" + api_nonce
+        api_post: str = f"nonce={api_nonce}"
 
         if data is not None:
             for key, value in data.items():
-                api_post += f"&{key}={value}"
+                encoded_key = urllib.parse.quote(str(key))
+                encoded_value = urllib.parse.quote(str(value))
+                api_post += f"&{encoded_key}={encoded_value}"
 
         # Cryptographic hash algorithms
         api_sha256: bytes = hashlib.sha256(bytes(api_nonce + api_post, 'utf-8')).digest()

--- a/hummingbot/connector/exchange/kraken/kraken_exchange.py
+++ b/hummingbot/connector/exchange/kraken/kraken_exchange.py
@@ -656,7 +656,7 @@ class KrakenExchange(ExchangePyBase):
             # Kraken responds 'Invalid Order ID: XXX-XXX' for STOP_LOSS/TAKE_PROFIT/TRAILING_STOP orders
             # which we identify in Hummingbot as 'DelayedOrder' delayed market orders.
             # Here we simply do not inquiry for trade updates for these orders.
-            if order.is_delayed:
+            if order.order_type.is_delayed_market_type():
                 return trade_updates
 
             exchange_order_id = await order.get_exchange_order_id()

--- a/hummingbot/connector/exchange/kraken/kraken_exchange.py
+++ b/hummingbot/connector/exchange/kraken/kraken_exchange.py
@@ -57,7 +57,7 @@ class KrakenExchange(ExchangePyBase):
         self._domain = domain
         self._trading_required = trading_required
         self._trading_pairs = trading_pairs
-        self._kraken_api_tier = KrakenAPITier(kraken_api_tier.upper())
+        self._kraken_api_tier = KrakenAPITier(kraken_api_tier.upper() if kraken_api_tier else "STARTER")
         self._asset_pairs = {}
         self._client_config = client_config_map
         self._client_order_id_nonce_provider = NonceCreator.for_microseconds()
@@ -126,7 +126,17 @@ class KrakenExchange(ExchangePyBase):
         return self._trading_required
 
     def supported_order_types(self):
-        return [OrderType.LIMIT, OrderType.LIMIT_MAKER, OrderType.MARKET]
+        return [
+            OrderType.LIMIT,
+            OrderType.LIMIT_MAKER,
+            OrderType.MARKET,
+            OrderType.STOP_LOSS,
+            OrderType.TAKE_PROFIT,
+            OrderType.TRAILING_STOP,
+            # OrderType.STOP_LOSS_LIMIT,
+            # OrderType.TAKE_PROFIT_LIMIT,
+            # OrderType.TRAILING_STOP_LIMIT,
+        ]
 
     def _build_async_throttler(self, api_tier: KrakenAPITier) -> AsyncThrottler:
         limits_pct = self._client_config.rate_limits_share_pct
@@ -209,6 +219,13 @@ class KrakenExchange(ExchangePyBase):
         """
         return bool(re.search(r"HTTP status is (5|10)\d\d\.", str(exception)))
 
+    @staticmethod
+    def is_market_service_exception(exception: Exception):
+        """
+        Error status Market in cancel-only mode
+        """
+        return "EService:Market in cancel_only mode" in str(exception)
+
     async def get_open_orders_with_userref(self, userref: int):
         data = {'userref': userref}
         return await self._api_request_with_retry(RESTMethod.POST,
@@ -229,7 +246,7 @@ class KrakenExchange(ExchangePyBase):
 
         :param trading_pair: the token pair to operate with
         :param amount: the order amount
-        :param order_type: the type of order to create (MARKET, LIMIT, LIMIT_MAKER)
+        :param order_type: the type of order to create (MARKET, LIMIT, LIMIT_MAKER, STOP_LOSS, TAKE_PROFIT, TRAILING_STOP)
         :param price: the order price
 
         :return: the id assigned by the connector to the order (the client id)
@@ -238,13 +255,17 @@ class KrakenExchange(ExchangePyBase):
             nonce_creator=self._client_order_id_nonce_provider,
             max_id_bit_count=CONSTANTS.MAX_ID_BIT_COUNT,
         ))
-        safe_ensure_future(self._create_order(
-            trade_type=TradeType.BUY,
-            order_id=order_id,
-            trading_pair=trading_pair,
-            amount=amount,
-            order_type=order_type,
-            price=price))
+        safe_ensure_future(
+            self._create_order(
+                trade_type=TradeType.BUY,
+                order_id=order_id,
+                trading_pair=trading_pair,
+                amount=amount,
+                order_type=order_type,
+                price=price,
+                **kwargs,
+            )
+        )
         return order_id
 
     def sell(self,
@@ -257,7 +278,7 @@ class KrakenExchange(ExchangePyBase):
         Creates a promise to create a sell order using the parameters.
         :param trading_pair: the token pair to operate with
         :param amount: the order amount
-        :param order_type: the type of order to create (MARKET, LIMIT, LIMIT_MAKER)
+        :param order_type: the type of order to create (MARKET, LIMIT, LIMIT_MAKER, STOP_LOSS, TAKE_PROFIT, TRAILING_STOP)
         :param price: the order price
         :return: the id assigned by the connector to the order (the client id)
         """
@@ -265,13 +286,17 @@ class KrakenExchange(ExchangePyBase):
             nonce_creator=self._client_order_id_nonce_provider,
             max_id_bit_count=CONSTANTS.MAX_ID_BIT_COUNT,
         ))
-        safe_ensure_future(self._create_order(
-            trade_type=TradeType.SELL,
-            order_id=order_id,
-            trading_pair=trading_pair,
-            amount=amount,
-            order_type=order_type,
-            price=price))
+        safe_ensure_future(
+            self._create_order(
+                trade_type=TradeType.SELL,
+                order_id=order_id,
+                trading_pair=trading_pair,
+                amount=amount,
+                order_type=order_type,
+                price=price,
+                **kwargs,
+            )
+        )
         return order_id
 
     async def get_asset_pairs(self) -> Dict[str, Any]:
@@ -295,16 +320,91 @@ class KrakenExchange(ExchangePyBase):
         data = {
             "pair": trading_pair,
             "type": "buy" if trade_type is TradeType.BUY else "sell",
-            "ordertype": "market" if order_type is OrderType.MARKET else "limit",
             "volume": str(amount),
-            "userref": order_id,
-            "price": str(price)
+            "userref": order_id,  # This is a non-unique field, useful to group batches of orders
+            # "cl_order_id": order_id, # Kraken supports unique client order id
+            "price": str(price),
+            # "timeinforce": "GTC",
+            # "starttm": "0",
+            # "expiretm": "0",
         }
 
+        if kwargs.get("price_in_percent", False):
+            data["price"] = f"#{price}%"
+
+        if (
+            order_type
+            in {
+                OrderType.STOP_LOSS,
+                # OrderType.STOP_LOSS_LIMIT,
+                OrderType.TAKE_PROFIT,
+                # OrderType.TAKE_PROFIT_LIMIT,
+                OrderType.TRAILING_STOP,
+                # OrderType.TRAILING_STOP_LIMIT,
+            }
+            and "price_in_percent" not in kwargs
+        ):
+            self.logger().debug(f"kwargs: {kwargs}")
+            raise ValueError(f"{order_type} order requires to clarify if price is in percent with 'price_in_percent=True/False'")
+
+        # if (
+        #     order_type
+        #     in {
+        #         OrderType.STOP_LOSS_LIMIT,
+        #         OrderType.TAKE_PROFIT_LIMIT,
+        #         OrderType.TRAILING_STOP_LIMIT,
+        #     }
+        # ):
+        #     if "price2" not in kwargs and "limit_price" not in kwargs:
+        #         self.logger().debug(f"kwargs: {kwargs}")
+        #         raise ValueError(f"{order_type} order requires a limit price: 'price2=str or limit_price=str'")
+        #     if "price2" in kwargs and "limit_price" in kwargs:
+        #         self.logger().debug(f"kwargs: {kwargs}")
+        #         raise ValueError(f"{order_type} order cannot specify both: 'price2=str and limit_price=str'")
+        #     price2: Decimal = kwargs.get("price2", kwargs.get("limit_price"))
+        #     if not isinstance(price2, Decimal):
+        #         self.logger().debug(f"kwargs: {kwargs}")
+        #         raise ValueError(f"{order_type} order limit price must be Decimal")
+        #     data["price2"] = f"{price2:+}%"
+
         if order_type is OrderType.MARKET:
+            data["ordertype"] = "market"
             del data["price"]
-        if order_type is OrderType.LIMIT_MAKER:
+
+        elif order_type is OrderType.LIMIT:
+            data["ordertype"] = "limit"
+
+        elif order_type is OrderType.LIMIT_MAKER:
+            data["ordertype"] = "limit"
             data["oflags"] = "post"
+
+        elif order_type is OrderType.STOP_LOSS:
+            data["ordertype"] = "stop-loss"
+
+        # elif order_type is OrderType.STOP_LOSS_LIMIT:
+        #     data["ordertype"] = "stop-loss-limit"
+
+        elif order_type is OrderType.TAKE_PROFIT:
+            data["ordertype"] = "take-profit"
+
+        # elif order_type is OrderType.TAKE_PROFIT_LIMIT:
+        #     data["ordertype"] = "take-profit-limit"
+
+        elif order_type is OrderType.TRAILING_STOP:
+            data["ordertype"] = "trailing-stop"
+            data["price"] = data["price"].replace("#", "+")
+
+        # elif order_type is OrderType.TRAILING_STOP_LIMIT:
+        #     data["ordertype"] = "trailing-stop-limit"
+        #     data["price"] = data["price"].replace("#", "+")
+
+        elif hasattr(order_type, "name"):
+            raise ValueError(f"Order type {order_type.name} not supported")
+        else:
+            raise ValueError(f"Order type {order_type} is invalid")
+
+        self.logger().debug(f"  '-> Placing order {order_id} for {amount} {trading_pair} at {price} {trade_type.name} {order_type} with {kwargs}")
+        self.logger().debug(f"  '-> request data {data}")
         order_result = await self._api_request_with_retry(RESTMethod.POST,
                                                           CONSTANTS.ADD_ORDER_PATH_URL,
                                                           data=data,
@@ -327,13 +427,10 @@ class KrakenExchange(ExchangePyBase):
                 response_json = await self._api_request(path_url=path_url, method=method, params=params, data=data,
                                                         is_auth_required=is_auth_required)
 
-                if response_json.get("error") and "EAPI:Invalid nonce" in response_json.get("error", ""):
-                    self.logger().error(f"Invalid nonce error from {path_url}. " +
-                                        "Please ensure your Kraken API key nonce window is at least 10, " +
-                                        "and if needed reset your API key.")
-                result = response_json.get("result")
-                if not result or response_json.get("error"):
+                if response_json.get("error") or not response_json.get("result"):
                     raise IOError({"error": response_json})
+
+                result = response_json.get("result")
                 break
             except IOError as e:
                 if self.is_cloudflare_exception(e):
@@ -343,13 +440,27 @@ class KrakenExchange(ExchangePyBase):
                         response = await self.get_open_orders_with_userref(data.get('userref'))
                         if any(response.get("open").values()):
                             return response
+
                     self.logger().warning(
                         f"Cloudflare error. Attempt {retry_attempt + 1}/{self.REQUEST_ATTEMPTS}"
                         f" API command {method}: {path_url}"
                     )
                     await asyncio.sleep(retry_interval ** retry_attempt)
                     continue
+
+                elif self.is_market_service_exception(e):
+                    self.logger().error(f"Market in cancel-only mode error from {path_url}.")
+                    await asyncio.sleep((10 * retry_interval) ** retry_attempt)
+                    continue
+
+                elif isinstance(e, dict) and "EAPI:Invalid nonce" in e.get("error", ""):
+                    self.logger().error(f"Invalid nonce error from {path_url}. " +
+                                        "Please ensure your Kraken API key nonce window is at least 10, " +
+                                        "and if needed reset your API key.")
+                    raise ValueError("Invalid nonce error from Kraken API")
+
                 else:
+                    self.logger().error(f"Error fetching data from {path_url}, msg is {response_json}")
                     raise e
         if not result:
             raise IOError(f"Error fetching data from {path_url}, msg is {response_json}.")

--- a/hummingbot/connector/exchange/kraken/kraken_utils.py
+++ b/hummingbot/connector/exchange/kraken/kraken_utils.py
@@ -15,8 +15,8 @@ CENTRALIZED = True
 EXAMPLE_PAIR = "ETH-USDC"
 
 DEFAULT_FEES = TradeFeeSchema(
-    maker_percent_fee_decimal=Decimal("0.0025"),
-    taker_percent_fee_decimal=Decimal("0.004"),
+    maker_percent_fee_decimal=Decimal("0.2"),
+    taker_percent_fee_decimal=Decimal("0.35"),
 )
 
 

--- a/test/hummingbot/connector/exchange/kraken/test_kraken_exchange.py
+++ b/test/hummingbot/connector/exchange/kraken/test_kraken_exchange.py
@@ -2,8 +2,9 @@ import json
 import logging
 import re
 from decimal import Decimal
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any, Callable, Dict, List, Optional, Tuple
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from aioresponses import aioresponses
 from aioresponses.core import RequestCall
@@ -19,6 +20,7 @@ from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount, TradeFeeBase
 from hummingbot.core.event.events import MarketOrderFailureEvent
 from hummingbot.core.network_iterator import NetworkStatus
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
 
 
 class KrakenExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests):
@@ -1226,3 +1228,330 @@ class KrakenExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests)
                 }
             }
         }
+
+
+class TestKrakenExchange(IsolatedAsyncioWrapperTestCase):
+
+    async def asyncSetUp(self):
+        # Mock values for the required parameters
+        client_config_map = ClientConfigMap()
+        kraken_api_key = "mock_api_key"
+        kraken_secret_key = "mock_secret_key"
+
+        self.exchange = KrakenExchange(client_config_map, kraken_api_key, kraken_secret_key)
+        self.exchange.exchange_symbol_associated_to_pair = AsyncMock(return_value="BTC-USD")
+        self.exchange._api_request_with_retry = AsyncMock(return_value={"txid": ["txid1"]})
+
+    async def test_place_order_happy_path_limit_buy(self):
+        order_id = "order1"
+        amount = Decimal("1.0")
+        trade_type = TradeType.BUY
+        order_type = OrderType.LIMIT
+        price = Decimal("50000.0")
+
+        await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price)
+
+        self.exchange._api_request_with_retry.assert_called_once_with(
+            RESTMethod.POST,
+            CONSTANTS.ADD_ORDER_PATH_URL,
+            data={
+                "pair": "BTC-USD",
+                "type": "buy",
+                "volume": "1.0",
+                "userref": order_id,
+                "price": "50000.0",
+                "ordertype": "limit"
+            },
+            is_auth_required=True
+        )
+
+    async def test_place_order_happy_path_market_sell(self):
+        order_id = "order2"
+        amount = Decimal("2.0")
+        trade_type = TradeType.SELL
+        order_type = OrderType.MARKET
+        price = Decimal("0.0")
+
+        await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price)
+
+        self.exchange._api_request_with_retry.assert_called_once_with(
+            RESTMethod.POST,
+            CONSTANTS.ADD_ORDER_PATH_URL,
+            data={
+                "pair": "BTC-USD",
+                "type": "sell",
+                "volume": "2.0",
+                "userref": order_id,
+                "ordertype": "market"
+            },
+            is_auth_required=True
+        )
+
+    async def test_place_order_edge_case_small_amount(self):
+        order_id = "order3"
+        amount = Decimal("0.0001")
+        trade_type = TradeType.BUY
+        order_type = OrderType.LIMIT
+        price = Decimal("50000.0")
+
+        await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price)
+
+        self.exchange._api_request_with_retry.assert_called_once_with(
+            RESTMethod.POST,
+            CONSTANTS.ADD_ORDER_PATH_URL,
+            data={
+                "pair": "BTC-USD",
+                "type": "buy",
+                "volume": "0.0001",
+                "userref": order_id,
+                "price": "50000.0",
+                "ordertype": "limit"
+            },
+            is_auth_required=True
+        )
+
+    async def test_place_order_edge_case_trailing_stop(self):
+        order_id = "order4"
+        amount = Decimal("1.0")
+        trade_type = TradeType.BUY
+        order_type = OrderType.TRAILING_STOP
+        price = Decimal("0.05")
+        kwargs = {"price_in_percent": True}
+
+        await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price, **kwargs)
+
+        self.exchange._api_request_with_retry.assert_called_once_with(
+            RESTMethod.POST,
+            CONSTANTS.ADD_ORDER_PATH_URL,
+            data={
+                "pair": "BTC-USD",
+                "type": "buy",
+                "volume": "1.0",
+                "userref": order_id,
+                "price": "+0.05%",
+                "ordertype": "trailing-stop"
+            },
+            is_auth_required=True
+        )
+
+    async def test_place_order_not_in_percent_trailing_stop(self):
+        order_id = "order4"
+        amount = Decimal("1.0")
+        trade_type = TradeType.BUY
+        order_type = OrderType.TRAILING_STOP
+
+        price = Decimal("0.05")
+        kwargs = {"price_in_percent": False}
+
+        await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price, **kwargs)
+
+        self.exchange._api_request_with_retry.assert_called_once_with(
+            RESTMethod.POST,
+            CONSTANTS.ADD_ORDER_PATH_URL,
+            data={
+                "pair": "BTC-USD",
+                "type": "buy",
+                "volume": "1.0",
+                "userref": order_id,
+                "price": "0.05",  # <- Not in percent, with BTC above 30K, good luck!
+                "ordertype": "trailing-stop"
+            },
+            is_auth_required=True
+        )
+
+    async def test_place_order_fail_no_percent_trailing_stop(self):
+        order_id = "order4"
+        amount = Decimal("1.0")
+        trade_type = TradeType.BUY
+        order_type = OrderType.TRAILING_STOP
+        price = Decimal("0.05")
+        kwargs = {}
+
+        with self.assertRaises(ValueError) as context:
+            await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price, **kwargs)
+        self.assertEqual(str(context.exception), f"{order_type} order requires to clarify if price is in percent with 'price_in_percent=True/False'")
+
+#    async def test_place_order_edge_case_trailing_stop_limit(self):
+#        order_id = "order4"
+#        amount = Decimal("1.0")
+#        trade_type = TradeType.BUY
+#        order_type = OrderType.TRAILING_STOP_LIMIT
+#        price = Decimal("0.05")
+#        kwargs = {"price_in_percent": True, "limit_price": Decimal("0.06")}
+#
+#        await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price, **kwargs)
+#
+#        self.exchange._api_request_with_retry.assert_called_once_with(
+#            RESTMethod.POST,
+#            CONSTANTS.ADD_ORDER_PATH_URL,
+#            data={
+#                "pair": "BTC-USD",
+#                "type": "buy",
+#                "volume": "1.0",
+#                "userref": order_id,
+#                "price": "+0.05%",
+#                "price2": "+0.06%",
+#                "ordertype": "trailing-stop-limit"
+#            },
+#            is_auth_required=True
+#        )
+#
+#        kwargs = {"price_in_percent": True, "price2": Decimal("0.06")}
+#        self.exchange._api_request_with_retry.reset_mock()
+#        await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price, **kwargs)
+#
+#        self.exchange._api_request_with_retry.assert_called_once_with(
+#            RESTMethod.POST,
+#            CONSTANTS.ADD_ORDER_PATH_URL,
+#            data={
+#                "pair": "BTC-USD",
+#                "type": "buy",
+#                "volume": "1.0",
+#                "userref": order_id,
+#                "price": "+0.05%",
+#                "price2": "+0.06%",
+#                "ordertype": "trailing-stop-limit"
+#            },
+#            is_auth_required=True
+#        )
+#
+#        kwargs = {"price_in_percent": True, "price2": Decimal("-0.06")}
+#        self.exchange._api_request_with_retry.reset_mock()
+#        await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price, **kwargs)
+#
+#        self.exchange._api_request_with_retry.assert_called_once_with(
+#            RESTMethod.POST,
+#            CONSTANTS.ADD_ORDER_PATH_URL,
+#            data={
+#                "pair": "BTC-USD",
+#                "type": "buy",
+#                "volume": "1.0",
+#                "userref": order_id,
+#                "price": "+0.05%",
+#                "price2": "-0.06%",
+#                "ordertype": "trailing-stop-limit"
+#            },
+#            is_auth_required=True
+#        )
+
+#    async def test_place_order_not_in_percent_trailing_stop_limit(self):
+#        order_id = "order4"
+#        amount = Decimal("1.0")
+#        trade_type = TradeType.BUY
+#        order_type = OrderType.TRAILING_STOP_LIMIT
+#
+#        price = Decimal("0.05")
+#        kwargs = {"price_in_percent": False, "limit_price": Decimal("0.06")}
+#
+#        await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price, **kwargs)
+#
+#        self.exchange._api_request_with_retry.assert_called_once_with(
+#            RESTMethod.POST,
+#            CONSTANTS.ADD_ORDER_PATH_URL,
+#            data={
+#                "pair": "BTC-USD",
+#                "type": "buy",
+#                "volume": "1.0",
+#                "userref": order_id,
+#                "price": "0.05",  # <- Not in percent, with BTC above 30K, good luck!
+#                "price2": "+0.06%",
+#                "ordertype": "trailing-stop-limit",
+#            },
+#            is_auth_required=True
+#        )
+
+#    async def test_place_order_fail_no_percent_trailing_stop_limit(self):
+#        order_id = "order4"
+#        amount = Decimal("1.0")
+#        trade_type = TradeType.BUY
+#        order_type = OrderType.TRAILING_STOP_LIMIT
+#        price = Decimal("0.05")
+#        kwargs = {}
+#
+#        with self.assertRaises(ValueError) as context:
+#            await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price, **kwargs)
+#        self.assertEqual(str(context.exception), f"{order_type} order requires to clarify if price is in percent with 'price_in_percent=True/False'")
+
+    async def test_place_order_edge_case_stop_loss(self):
+        order_id = "order4"
+        amount = Decimal("1.0")
+        trade_type = TradeType.BUY
+        order_type = OrderType.STOP_LOSS
+        price = Decimal("0.05")
+        kwargs = {"price_in_percent": True}
+
+        await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price, **kwargs)
+
+        self.exchange._api_request_with_retry.assert_called_once_with(
+            RESTMethod.POST,
+            CONSTANTS.ADD_ORDER_PATH_URL,
+            data={
+                "pair": "BTC-USD",
+                "type": "buy",
+                "volume": "1.0",
+                "userref": order_id,
+                "price": "#0.05%",
+                "ordertype": "stop-loss"
+            },
+            is_auth_required=True
+        )
+
+    async def test_place_order_fail_no_percent_stop_loss(self):
+        order_id = "order4"
+        amount = Decimal("1.0")
+        trade_type = TradeType.BUY
+        order_type = OrderType.STOP_LOSS
+        price = Decimal("0.05")
+        kwargs = {}
+
+        with self.assertRaises(ValueError) as context:
+            await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price, **kwargs)
+        self.assertEqual(str(context.exception), f"{order_type} order requires to clarify if price is in percent with 'price_in_percent=True/False'")
+
+    async def test_place_order_edge_case_take_profit(self):
+        order_id = "order4"
+        amount = Decimal("1.0")
+        trade_type = TradeType.BUY
+        order_type = OrderType.TAKE_PROFIT
+        price = Decimal("0.05")
+        kwargs = {"price_in_percent": True}
+
+        await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price, **kwargs)
+
+        self.exchange._api_request_with_retry.assert_called_once_with(
+            RESTMethod.POST,
+            CONSTANTS.ADD_ORDER_PATH_URL,
+            data={
+                "pair": "BTC-USD",
+                "type": "buy",
+                "volume": "1.0",
+                "userref": order_id,
+                "price": "#0.05%",
+                "ordertype": "take-profit"
+            },
+            is_auth_required=True
+        )
+
+    async def test_place_order_fail_no_percent_take_profit(self):
+        order_id = "order4"
+        amount = Decimal("1.0")
+        trade_type = TradeType.BUY
+        order_type = OrderType.TAKE_PROFIT
+        price = Decimal("0.05")
+        kwargs = {}
+
+        with self.assertRaises(ValueError) as context:
+            await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price, **kwargs)
+        self.assertEqual(str(context.exception), f"{order_type} order requires to clarify if price is in percent with 'price_in_percent=True/False'")
+
+    async def test_place_order_error_invalid_order_type(self):
+        order_id = "order5"
+        amount = Decimal("1.0")
+        trade_type = TradeType.BUY
+        order_type = 999
+        price = Decimal("50000.0")
+
+        with self.assertRaises(ValueError) as context:
+            await self.exchange._place_order(order_id, "BTC-USD", amount, trade_type, order_type, price)
+
+        self.assertEqual(str(context.exception), "Order type 999 is invalid")

--- a/test/hummingbot/connector/exchange/kraken/test_kraken_exchange.py
+++ b/test/hummingbot/connector/exchange/kraken/test_kraken_exchange.py
@@ -422,7 +422,17 @@ class KrakenExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests)
 
     @property
     def expected_supported_order_types(self):
-        return [OrderType.LIMIT, OrderType.LIMIT_MAKER, OrderType.MARKET]
+        return [
+            OrderType.LIMIT,
+            OrderType.LIMIT_MAKER,
+            OrderType.MARKET,
+            OrderType.STOP_LOSS,
+            OrderType.TAKE_PROFIT,
+            OrderType.TRAILING_STOP,
+            # OrderType.STOP_LOSS_LIMIT,
+            # OrderType.TAKE_PROFIT_LIMIT,
+            # OrderType.TRAILING_STOP_LIMIT,
+        ]
 
     @property
     def expected_trading_rule(self):


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
This is a companion to the PR on new order types. Thie PR fails since the new order types are not implemented in core


**Tests performed by the developer**:



**Tips for QA testing**:

## Summary by Sourcery

Enhance the Kraken exchange connector by adding support for new order types such as STOP_LOSS, TAKE_PROFIT, and TRAILING_STOP. Improve nonce generation for authentication and refine error handling for market service exceptions and invalid nonce errors. Update tests to reflect the new order types.

New Features:
- Add support for new order types including STOP_LOSS, TAKE_PROFIT, and TRAILING_STOP in the Kraken exchange connector.

Bug Fixes:
- Fix error handling for market service exceptions and invalid nonce errors in the Kraken exchange connector.

Enhancements:
- Improve nonce generation in Kraken authentication by using milliseconds for higher precision.

Tests:
- Update tests to include new supported order types in the Kraken exchange connector.