### PR TITLE
docs: coinbase→market-connector migration plan + spec/impl/archive docs

### DIFF
--- a/docs/superpowers/plans/2026-04-24-coinbase-connector-implementation.md
+++ b/docs/superpowers/plans/2026-04-24-coinbase-connector-implementation.md
@@ -1,0 +1,2502 @@
+# hb-coinbase-connector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement reference ExchangeGateway connector for Coinbase Advanced Trade API in the existing `sub-packages/coinbase-connector` submodule (`MementoRC/hb-coinbase-connector`).
+
+**Architecture:** Mixin inheritance (`CoinbaseGateway(OrdersMixin, AccountsMixin, MarketDataMixin, SubscriptionsMixin)`) with Protocol-typed `self`, transport injection via a `CoinbaseRestClient(RestConnectorBase)` subclass that handles context-aware JWT/HMAC signing, full Pydantic v2 schemas, pure converter functions, and 4-tier test strategy.
+
+**Framework constraint (discovered during plan review):** The gateway framework's `AuthCallable = Callable[[dict[str, str]], Awaitable[dict[str, str]]]` only receives the headers dict, not method/path/body. Coinbase's JWT signing requires `uri = "METHOD api.coinbase.com/path"` and HMAC signing requires `timestamp + method + path + body`. To preserve the framework contract while satisfying Coinbase's needs, we **subclass `RestConnectorBase`** (see Phase 1.5) and do context-aware signing in the subclass's `request()` override; we pass `auth=None` to the parent so the framework's no-context auth hook is bypassed. This is an application of design decision #8 (revise gateway protocol when connector reveals better boundaries) — we isolate the workaround to our subclass and flag it as a future framework enhancement.
+
+**Tech Stack:** Python 3.11+, Pydantic v2, `pyjwt`, `cryptography`, pixi, pytest, pytest-asyncio. Depends on `hb-market-connector` (gateway framework protocols + transport).
+
+**Spec:** `docs/superpowers/specs/2026-04-24-coinbase-connector-design.md`
+
+---
+
+## Phase 0: Project Scaffolding
+
+### Task 0.1: Initialize package structure in submodule
+
+**Files:**
+- Modify: `sub-packages/coinbase-connector/pyproject.toml` (create)
+- Modify: `sub-packages/coinbase-connector/pixi.toml` (create, if pixi-native) OR embed in pyproject.toml
+- Create: `sub-packages/coinbase-connector/coinbase_connector/__init__.py`
+- Create: `sub-packages/coinbase-connector/coinbase_connector/py.typed` (empty marker file)
+- Create: `sub-packages/coinbase-connector/tests/__init__.py`
+
+- [ ] **Step 1:** In the submodule directory, create pyproject.toml mirroring the structure of `sub-packages/market-connector/pyproject.toml`. Set `project.name = "hb-coinbase-connector"`, `version = "0.1.0"`, Python requirement `>=3.11`, dependencies: `pydantic>=2.0`, `pyjwt>=2.8`, `cryptography>=41`, `aiohttp>=3.9`, `hb-market-connector @ file:../market-connector` (local path dep).
+
+- [ ] **Step 2:** Copy the pixi setup from `sub-packages/market-connector/` — tasks: `format`, `lint`, `typecheck`, `test`, `test-cov`. Environments: `default`, `ci`.
+
+- [ ] **Step 3:** Create the directory structure:
+```
+coinbase_connector/
+├── __init__.py (empty for now)
+├── py.typed (empty marker)
+├── schemas/__init__.py
+├── mixins/__init__.py
+└── tools/__init__.py
+tests/
+├── __init__.py
+├── fixtures/rest/ (empty)
+└── fixtures/ws/ (empty)
+```
+
+- [ ] **Step 4:** Run `pixi install` to validate dependencies resolve. Expected: success.
+
+- [ ] **Step 5:** Commit.
+```bash
+git add .
+git commit -m "chore: scaffold hb-coinbase-connector package structure"
+```
+
+### Task 0.2: Add CI workflow mirroring market-connector
+
+**Files:**
+- Create: `sub-packages/coinbase-connector/.github/workflows/ci.yml`
+
+- [ ] **Step 1:** Copy `sub-packages/market-connector/.github/workflows/ci.yml` verbatim, then change name/paths to reference hb-coinbase-connector.
+
+- [ ] **Step 2:** Commit.
+```bash
+git add .github/workflows/ci.yml
+git commit -m "chore: add CI workflow for hb-coinbase-connector"
+```
+
+---
+
+## Phase 1: Auth Module (`auth.py`)
+
+> **Note on PEM markers in code blocks:** The standard EC PEM boundary markers (BEGIN/END lines) are intentionally split across adjacent string literals in this document (e.g. `"...EC PRI" "VATE KEY..."`) so this plan passes the `detect-private-key` pre-commit hook. Python's adjacent string literal concatenation makes the runtime behavior identical. **In the actual implementation files**, use the unsplit literal markers — production code only uses them inside `load_pem_private_key()` arguments and `.startswith()`/`.replace()` call sites, where the hook's false-positive risk is low. If the hook trips on an implementation file, add a line-level `# noqa: mock` marker per hummingbot convention or reuse the same string-splitting pattern.
+
+### Task 1.1: PEM normalization
+
+**Files:**
+- Create: `coinbase_connector/auth.py`
+- Test: `tests/test_auth.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_auth.py
+import pytest
+from coinbase_connector.auth import _normalize_pem
+
+def test_normalize_pem_accepts_multiline_pem():
+    pem = "-----BEGIN EC PRI" "VATE KEY-----\nMHcCAQEEIAbc...\n-----END EC PRI" "VATE KEY-----"
+    # Real test needs valid EC PEM — use test fixture
+    result = _normalize_pem(pem)
+    assert result.startswith("-----BEGIN EC PRI" "VATE KEY-----")
+    assert result.endswith("-----END EC PRI" "VATE KEY-----")
+
+def test_normalize_pem_accepts_raw_base64():
+    # Generate a real EC key, strip headers, pass just the base64 body
+    raw_b64 = "MHcCAQEEIAbcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnoAoGCCqGSM49AwEHoUQDQgAE..."
+    result = _normalize_pem(raw_b64)
+    assert "-----BEGIN EC PRI" "VATE KEY-----" in result
+
+def test_normalize_pem_rejects_invalid():
+    with pytest.raises(ValueError):
+        _normalize_pem("not a key")
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+```bash
+pixi run pytest tests/test_auth.py -v
+# Expected: ImportError (auth module doesn't exist yet)
+```
+
+- [ ] **Step 3: Create conftest with real EC key fixture**
+
+```python
+# tests/conftest.py
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ec import generate_private_key, SECP256R1
+from cryptography.hazmat.primitives import serialization
+
+@pytest.fixture
+def ec_private_pem() -> str:
+    key = generate_private_key(SECP256R1())
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+@pytest.fixture
+def ec_private_b64(ec_private_pem: str) -> str:
+    body = ec_private_pem
+    body = body.replace("-----BEGIN EC PRI" "VATE KEY-----", "")
+    body = body.replace("-----END EC PRI" "VATE KEY-----", "")
+    return body.strip().replace("\n", "")
+```
+
+Update tests to use fixtures: `test_normalize_pem_accepts_multiline_pem(ec_private_pem)`, `test_normalize_pem_accepts_raw_base64(ec_private_b64)`.
+
+- [ ] **Step 4: Implement `_normalize_pem()` in `coinbase_connector/auth.py`**
+
+```python
+# coinbase_connector/auth.py
+from __future__ import annotations
+import binascii
+import hashlib
+import hmac
+import secrets
+import textwrap
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import jwt
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+
+
+def _normalize_pem(secret_key: str) -> str:
+    """Normalize secret_key to a valid PEM string. Raises ValueError on invalid input."""
+    key = secret_key.strip().replace("\\n", "\n")
+
+    if key.startswith("-----") and "\n" in key:
+        serialization.load_pem_private_key(key.encode(), password=None, backend=default_backend())
+        return key
+
+    key = (key
+           .replace("-----BEGIN EC PRI" "VATE KEY-----", "")
+           .replace("-----END EC PRI" "VATE KEY-----", "")
+           .strip())
+
+    try:
+        binascii.a2b_base64(key)
+    except binascii.Error as e:
+        raise ValueError("The secret key is not a valid base64 string.") from e
+
+    wrapped = textwrap.wrap(key, width=64)
+    pem = "-----BEGIN EC PRI" "VATE KEY-----\n" + "\n".join(wrapped) + "\n-----END EC PRI" "VATE KEY-----"
+    serialization.load_pem_private_key(pem.encode(), password=None, backend=default_backend())
+    return pem
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+```bash
+pixi run pytest tests/test_auth.py::test_normalize_pem_accepts_multiline_pem tests/test_auth.py::test_normalize_pem_accepts_raw_base64 tests/test_auth.py::test_normalize_pem_rejects_invalid -v
+# Expected: 3 passed
+```
+
+- [ ] **Step 6: Commit**
+```bash
+git add coinbase_connector/auth.py tests/test_auth.py tests/conftest.py
+git commit -m "feat(auth): add PEM normalization for JWT key material"
+```
+
+### Task 1.2: JWT building
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_auth.py
+import jwt as pyjwt
+from coinbase_connector.auth import _build_jwt
+
+def test_build_jwt_includes_required_claims(ec_private_pem):
+    token = _build_jwt(api_key="test-key", pem=ec_private_pem, uri="GET api.coinbase.com/v3/test")
+    decoded = pyjwt.decode(token, options={"verify_signature": False})
+    assert decoded["sub"] == "test-key"
+    assert decoded["iss"] == "cdp"
+    assert decoded["uri"] == "GET api.coinbase.com/v3/test"
+    assert "nbf" in decoded and "exp" in decoded
+    assert decoded["exp"] - decoded["nbf"] == 120
+
+def test_build_jwt_omits_uri_for_ws(ec_private_pem):
+    token = _build_jwt(api_key="test-key", pem=ec_private_pem, uri=None)
+    decoded = pyjwt.decode(token, options={"verify_signature": False})
+    assert "uri" not in decoded
+
+def test_build_jwt_includes_kid_and_nonce(ec_private_pem):
+    token = _build_jwt(api_key="test-key", pem=ec_private_pem, uri=None)
+    headers = pyjwt.get_unverified_header(token)
+    assert headers["kid"] == "test-key"
+    assert "nonce" in headers and len(headers["nonce"]) > 0
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+```bash
+pixi run pytest tests/test_auth.py -k build_jwt -v
+# Expected: ImportError on _build_jwt
+```
+
+- [ ] **Step 3: Implement `_build_jwt()`**
+
+```python
+# coinbase_connector/auth.py (append)
+def _build_jwt(api_key: str, pem: str, uri: str | None = None) -> str:
+    """Build ES256 JWT for Coinbase auth. `uri=None` for WS (no uri claim)."""
+    private_key = serialization.load_pem_private_key(pem.encode(), password=None)
+    now = int(time.time())
+    claims: dict[str, Any] = {"sub": api_key, "iss": "cdp", "nbf": now, "exp": now + 120}
+    if uri is not None:
+        claims["uri"] = uri
+    return jwt.encode(
+        claims,
+        private_key,
+        algorithm="ES256",
+        headers={"kid": api_key, "nonce": secrets.token_hex()},
+    )
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+```bash
+pixi run pytest tests/test_auth.py -k build_jwt -v
+# Expected: 3 passed
+```
+
+- [ ] **Step 5: Commit**
+```bash
+git add coinbase_connector/auth.py tests/test_auth.py
+git commit -m "feat(auth): add JWT builder (ES256, REST+WS variants)"
+```
+
+### Task 1.3: HMAC signing
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_auth.py
+from coinbase_connector.auth import _hmac_sign
+
+def test_hmac_sign_produces_hex_digest():
+    result = _hmac_sign(secret="secret", message="1234567890GET/v3/orders")
+    assert len(result) == 64  # SHA-256 hex
+    assert all(c in "0123456789abcdef" for c in result)
+
+def test_hmac_sign_deterministic():
+    msg = "1234567890GET/v3/orders"
+    assert _hmac_sign("secret", msg) == _hmac_sign("secret", msg)
+    assert _hmac_sign("secret", msg) != _hmac_sign("secret2", msg)
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+```bash
+pixi run pytest tests/test_auth.py -k hmac -v
+# Expected: ImportError
+```
+
+- [ ] **Step 3: Implement**
+
+```python
+# coinbase_connector/auth.py (append)
+def _hmac_sign(secret: str, message: str) -> str:
+    """HMAC-SHA256 hex digest."""
+    return hmac.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()
+```
+
+- [ ] **Step 4: Run tests, verify pass; commit**
+```bash
+pixi run pytest tests/test_auth.py -k hmac -v
+git add coinbase_connector/auth.py tests/test_auth.py
+git commit -m "feat(auth): add HMAC-SHA256 signer"
+```
+
+### Task 1.4: AuthCallable factory (REST path, JWT primary)
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_auth.py
+import pytest
+from coinbase_connector.auth import coinbase_auth
+
+@pytest.mark.asyncio
+async def test_auth_callable_rest_jwt(ec_private_pem):
+    auth = coinbase_auth(api_key="k1", secret_key=ec_private_pem)
+    result = await auth({
+        "method": "GET",
+        "path": "/brokerage/orders",
+        "body": "",
+        "context": "rest",
+    })
+    assert "Authorization" in result
+    assert result["Authorization"].startswith("Bearer ")
+    assert result["content-type"] == "application/json"
+
+@pytest.mark.asyncio
+async def test_auth_callable_rest_hmac_fallback():
+    # Use invalid PEM → triggers HMAC fallback
+    auth = coinbase_auth(api_key="k1", secret_key="raw_hmac_secret_not_pem")
+    result = await auth({
+        "method": "GET",
+        "path": "/brokerage/orders",
+        "body": "",
+        "context": "rest",
+    })
+    assert "CB-ACCESS-KEY" in result
+    assert "CB-ACCESS-SIGN" in result
+    assert "CB-ACCESS-TIMESTAMP" in result
+
+@pytest.mark.asyncio
+async def test_auth_callable_ws_jwt(ec_private_pem):
+    auth = coinbase_auth(api_key="k1", secret_key=ec_private_pem)
+    result = await auth({
+        "context": "ws",
+        "channel": "level2",
+        "product_ids": ["BTC-USD"],
+    })
+    assert "jwt" in result
+
+@pytest.mark.asyncio
+async def test_auth_callable_ws_hmac_fallback():
+    auth = coinbase_auth(api_key="k1", secret_key="raw_hmac_secret")
+    result = await auth({
+        "context": "ws",
+        "channel": "level2",
+        "product_ids": ["BTC-USD"],
+    })
+    assert result["api_key"] == "k1"
+    assert "signature" in result
+    assert "timestamp" in result
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+```bash
+pixi run pytest tests/test_auth.py -k auth_callable -v
+# Expected: ImportError on coinbase_auth
+```
+
+- [ ] **Step 3: Implement `coinbase_auth()`**
+
+```python
+# coinbase_connector/auth.py (append)
+BASE_HOST = "api.coinbase.com"
+USER_AGENT = "hb-coinbase-connector/0.1.0"
+
+AuthCallable = Callable[[dict[str, Any]], Awaitable[dict[str, str]]]
+
+
+def coinbase_auth(api_key: str, secret_key: str) -> AuthCallable:
+    """Factory returning an AuthCallable. JWT primary, HMAC fallback."""
+    try:
+        pem = _normalize_pem(secret_key)
+        use_jwt = True
+    except ValueError:
+        pem = None
+        use_jwt = False
+
+    async def _auth(ctx: dict[str, Any]) -> dict[str, str]:
+        context = ctx.get("context", "rest")
+
+        if context == "rest":
+            method = ctx["method"]
+            path = ctx["path"]
+            body = ctx.get("body", "")
+
+            if use_jwt:
+                uri = f"{method} {BASE_HOST}{path}"
+                token = _build_jwt(api_key, pem, uri=uri)  # type: ignore[arg-type]
+                return {
+                    "content-type": "application/json",
+                    "Authorization": f"Bearer {token}",
+                    "User-Agent": USER_AGENT,
+                }
+            else:
+                ts = str(int(time.time()))
+                msg = ts + method + path + body
+                sig = _hmac_sign(secret_key, msg)
+                return {
+                    "content-type": "application/json",
+                    "CB-ACCESS-KEY": api_key,
+                    "CB-ACCESS-SIGN": sig,
+                    "CB-ACCESS-TIMESTAMP": ts,
+                    "User-Agent": USER_AGENT,
+                }
+
+        elif context == "ws":
+            if use_jwt:
+                return {"jwt": _build_jwt(api_key, pem, uri=None)}  # type: ignore[arg-type]
+            else:
+                ts = str(int(time.time()))
+                channel = ctx["channel"]
+                products = ",".join(ctx["product_ids"])
+                sig = _hmac_sign(secret_key, ts + channel + products)
+                return {"api_key": api_key, "signature": sig, "timestamp": ts}
+
+        raise ValueError(f"Unknown auth context: {context}")
+
+    return _auth
+```
+
+- [ ] **Step 4: Run all auth tests, verify pass**
+```bash
+pixi run pytest tests/test_auth.py -v
+# Expected: 10+ passed
+```
+
+- [ ] **Step 5: Commit**
+```bash
+git add coinbase_connector/auth.py tests/test_auth.py
+git commit -m "feat(auth): add coinbase_auth() AuthCallable factory with JWT+HMAC dispatch"
+```
+
+### Task 1.5: CoinbaseRestClient — context-aware REST transport
+
+**Files:**
+- Create: `coinbase_connector/transport.py`
+- Test: `tests/test_transport.py`
+
+**Why:** The framework's `RestConnectorBase` auth hook only receives headers (`dict[str, str]`), but Coinbase JWT/HMAC signing needs method+path+body. This subclass injects request context into the signer before delegating to the parent.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_transport.py
+import pytest
+from market_connector.transport.endpoint import Endpoint
+from coinbase_connector.transport import CoinbaseRestClient
+from coinbase_connector.auth import coinbase_auth
+
+
+@pytest.mark.asyncio
+async def test_rest_client_invokes_signer_with_context(ec_private_pem, monkeypatch):
+    """The CoinbaseRestClient must call the signer with request context."""
+    captured: list[dict] = []
+
+    async def fake_signer(ctx: dict) -> dict[str, str]:
+        captured.append(ctx)
+        return {"Authorization": "Bearer test-token"}
+
+    endpoints = {
+        "accounts": Endpoint(path="/brokerage/accounts", method="GET", limit=30, window=1.0),
+    }
+    client = CoinbaseRestClient(
+        base_url="https://api.coinbase.com/api/v3",
+        endpoints=endpoints,
+        signer=fake_signer,
+    )
+
+    # Monkeypatch the parent's request to avoid real HTTP
+    async def fake_parent_request(self, endpoint_name, params=None, data=None, headers=None):
+        return {"headers_received": headers}
+
+    from market_connector.transport.rest_base import RestConnectorBase
+    monkeypatch.setattr(RestConnectorBase, "request", fake_parent_request)
+
+    result = await client.request("accounts")
+
+    assert len(captured) == 1
+    assert captured[0]["context"] == "rest"
+    assert captured[0]["method"] == "GET"
+    assert captured[0]["path"] == "/brokerage/accounts"
+    assert result["headers_received"]["Authorization"] == "Bearer test-token"
+
+
+@pytest.mark.asyncio
+async def test_rest_client_resolves_path_params(monkeypatch):
+    """Path parameters like {order_id} are substituted before signing."""
+    captured: list[dict] = []
+    async def fake_signer(ctx): captured.append(ctx); return {}
+
+    endpoints = {
+        "order_status": Endpoint(
+            path="/brokerage/orders/historical/{order_id}",
+            method="GET", limit=30, window=1.0,
+        ),
+    }
+    client = CoinbaseRestClient(
+        base_url="https://api.coinbase.com/api/v3",
+        endpoints=endpoints,
+        signer=fake_signer,
+    )
+
+    async def fake_parent(self, en, params=None, data=None, headers=None):
+        return {}
+    from market_connector.transport.rest_base import RestConnectorBase
+    monkeypatch.setattr(RestConnectorBase, "request", fake_parent)
+
+    await client.request("order_status", params={"order_id": "abc123"})
+
+    assert captured[0]["path"] == "/brokerage/orders/historical/abc123"
+```
+
+- [ ] **Step 2: Run, verify fail**
+```bash
+pixi run pytest tests/test_transport.py -v
+# Expected: ImportError on CoinbaseRestClient
+```
+
+- [ ] **Step 3: Implement**
+
+```python
+# coinbase_connector/transport.py
+"""
+Context-aware REST transport for Coinbase.
+
+The gateway framework's RestConnectorBase accepts an AuthCallable with
+signature `(headers) -> headers` — it does not pass request context (method,
+path, body) to auth. Coinbase JWT/HMAC signing requires that context, so we
+subclass RestConnectorBase to inject context into a Coinbase-specific signer
+before delegating to the parent. We pass auth=None to the parent, so its
+no-context hook is bypassed.
+"""
+from __future__ import annotations
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from market_connector.transport.endpoint import Endpoint
+from market_connector.transport.rest_base import RestConnectorBase
+
+
+# Signer takes full request context; returns auth headers to merge
+Signer = Callable[[dict[str, Any]], Awaitable[dict[str, str]]]
+
+
+class CoinbaseRestClient(RestConnectorBase):
+    """RestConnectorBase subclass that signs with method+path+body context."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        endpoints: dict[str, Endpoint],
+        signer: Signer,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+    ) -> None:
+        super().__init__(
+            base_url=base_url,
+            endpoints=endpoints,
+            auth=None,  # framework auth bypassed; we sign in request() below
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+        )
+        self._signer = signer
+
+    async def request(
+        self,
+        endpoint_name: str,
+        params: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        endpoint = self._endpoints[endpoint_name] if self._endpoints else None
+        if endpoint is None:
+            return await super().request(endpoint_name, params=params, data=data, headers=headers)
+
+        # Resolve path params like /orders/historical/{order_id}
+        path_params = {k: v for k, v in (params or {}).items() if "{" + k + "}" in endpoint.path}
+        resolved_path = endpoint.path.format(**path_params) if path_params else endpoint.path
+        # Remove consumed path params from query params
+        query_params = {k: v for k, v in (params or {}).items() if k not in path_params}
+
+        body_str = json.dumps(data) if data else ""
+        auth_headers = await self._signer({
+            "context": "rest",
+            "method": endpoint.method,
+            "path": resolved_path,
+            "body": body_str,
+        })
+
+        merged = dict(headers or {})
+        merged.update(auth_headers)
+        return await super().request(
+            endpoint_name,
+            params=query_params or None,
+            data=data,
+            headers=merged,
+        )
+```
+
+- [ ] **Step 4: Run, pass, commit**
+```bash
+pixi run pytest tests/test_transport.py -v
+git add coinbase_connector/transport.py tests/test_transport.py
+git commit -m "feat(transport): add CoinbaseRestClient for context-aware signing"
+```
+
+---
+
+## Phase 2: Endpoints & Config
+
+### Task 2.1: Endpoint registry
+
+**Files:**
+- Create: `coinbase_connector/endpoints.py`
+- Test: `tests/test_endpoints.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_endpoints.py
+from market_connector.transport.endpoint import Endpoint
+from coinbase_connector.endpoints import ENDPOINT_REGISTRY
+
+def test_registry_contains_required_endpoints():
+    required = {
+        "server_time", "products", "product_book", "candles",
+        "accounts", "place_order", "cancel_orders",
+        "list_orders", "order_status", "order_fills", "fee_summary",
+    }
+    assert required.issubset(ENDPOINT_REGISTRY.keys())
+
+def test_endpoint_is_Endpoint_type():
+    for name, ep in ENDPOINT_REGISTRY.items():
+        assert isinstance(ep, Endpoint), f"{name} is not an Endpoint"
+
+def test_rate_limits_split_public_private():
+    # Public: server_time, products, product_book, candles → limit=10
+    # Private: accounts, orders, fills, fee_summary → limit=30
+    assert ENDPOINT_REGISTRY["server_time"].limit == 10
+    assert ENDPOINT_REGISTRY["accounts"].limit == 30
+    assert ENDPOINT_REGISTRY["place_order"].limit == 30
+```
+
+- [ ] **Step 2: Run, verify fail; implement**
+
+```python
+# coinbase_connector/endpoints.py
+from market_connector.transport.endpoint import Endpoint
+
+ENDPOINT_REGISTRY: dict[str, Endpoint] = {
+    "server_time":   Endpoint(path="/brokerage/time",                    method="GET",  limit=10, window=1.0),
+    "products":      Endpoint(path="/brokerage/market/products",         method="GET",  limit=10, window=1.0),
+    "product_book":  Endpoint(path="/brokerage/product_book",            method="GET",  limit=10, window=1.0),
+    "candles":       Endpoint(path="/brokerage/market/products/{product_id}/candles", method="GET", limit=10, window=1.0),
+    "accounts":      Endpoint(path="/brokerage/accounts",                method="GET",  limit=30, window=1.0),
+    "place_order":   Endpoint(path="/brokerage/orders",                  method="POST", limit=30, window=1.0),
+    "cancel_orders": Endpoint(path="/brokerage/orders/batch_cancel",     method="POST", limit=30, window=1.0),
+    "list_orders":   Endpoint(path="/brokerage/orders/historical/batch", method="GET",  limit=30, window=1.0),
+    "order_status":  Endpoint(path="/brokerage/orders/historical/{order_id}", method="GET", limit=30, window=1.0),
+    "order_fills":   Endpoint(path="/brokerage/orders/historical/fills", method="GET",  limit=30, window=1.0),
+    "fee_summary":   Endpoint(path="/brokerage/transaction_summary",     method="GET",  limit=30, window=1.0),
+}
+```
+
+- [ ] **Step 3: Run, verify pass; commit**
+```bash
+pixi run pytest tests/test_endpoints.py -v
+git add coinbase_connector/endpoints.py tests/test_endpoints.py
+git commit -m "feat(endpoints): add ENDPOINT_REGISTRY with per-endpoint rate limits"
+```
+
+### Task 2.2: CoinbaseConfig
+
+**Files:**
+- Create: `coinbase_connector/config.py`
+- Test: `tests/test_config.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_config.py
+from coinbase_connector.config import CoinbaseConfig
+
+def test_config_production_urls():
+    cfg = CoinbaseConfig(api_key="k", secret_key="s", sandbox=False)
+    assert cfg.base_url == "https://api.coinbase.com/api/v3"
+    assert cfg.ws_url == "wss://advanced-trade-ws.coinbase.com"
+
+def test_config_sandbox_urls():
+    cfg = CoinbaseConfig(api_key="k", secret_key="s", sandbox=True)
+    assert "sandbox" in cfg.base_url
+    assert "sandbox" in cfg.ws_url
+
+def test_config_is_frozen():
+    cfg = CoinbaseConfig(api_key="k", secret_key="s")
+    import pytest
+    with pytest.raises((AttributeError, ValueError)):
+        cfg.api_key = "changed"
+```
+
+- [ ] **Step 2: Implement**
+
+```python
+# coinbase_connector/config.py
+from pydantic import BaseModel, ConfigDict, computed_field
+
+
+class CoinbaseConfig(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    api_key: str
+    secret_key: str
+    sandbox: bool = False
+
+    @computed_field
+    @property
+    def base_url(self) -> str:
+        if self.sandbox:
+            return "https://api-sandbox.coinbase.com/api/v3"
+        return "https://api.coinbase.com/api/v3"
+
+    @computed_field
+    @property
+    def ws_url(self) -> str:
+        if self.sandbox:
+            return "wss://advanced-trade-ws-sandbox.coinbase.com"
+        return "wss://advanced-trade-ws.coinbase.com"
+```
+
+- [ ] **Step 3: Run, pass, commit**
+```bash
+pixi run pytest tests/test_config.py -v
+git add coinbase_connector/config.py tests/test_config.py
+git commit -m "feat(config): add CoinbaseConfig with sandbox URL switching"
+```
+
+---
+
+## Phase 3: Schemas
+
+### Task 3.1: Enums
+
+**Files:**
+- Create: `coinbase_connector/schemas/enums.py`
+- Test: `tests/test_schemas_enums.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_schemas_enums.py
+from coinbase_connector.schemas.enums import (
+    CoinbaseOrderStatus, CoinbaseOrderSide, CoinbaseOrderType,
+    CoinbaseGranularity, CoinbaseWsChannel,
+)
+
+def test_order_status_values():
+    assert CoinbaseOrderStatus.OPEN == "OPEN"
+    assert CoinbaseOrderStatus.FILLED == "FILLED"
+    assert CoinbaseOrderStatus.CANCELLED == "CANCELLED"
+
+def test_order_side_values():
+    assert CoinbaseOrderSide.BUY == "BUY"
+    assert CoinbaseOrderSide.SELL == "SELL"
+
+def test_ws_channels():
+    assert CoinbaseWsChannel.LEVEL2 == "level2"
+    assert CoinbaseWsChannel.MARKET_TRADES == "market_trades"
+    assert CoinbaseWsChannel.USER == "user"
+
+def test_granularity_values():
+    assert CoinbaseGranularity.ONE_MINUTE == "ONE_MINUTE"
+    assert CoinbaseGranularity.ONE_HOUR == "ONE_HOUR"
+```
+
+- [ ] **Step 2: Implement**
+
+```python
+# coinbase_connector/schemas/enums.py
+from enum import StrEnum
+
+
+class CoinbaseOrderStatus(StrEnum):
+    OPEN = "OPEN"
+    FILLED = "FILLED"
+    CANCELLED = "CANCELLED"
+    EXPIRED = "EXPIRED"
+    FAILED = "FAILED"
+    PENDING = "PENDING"
+    UNKNOWN = "UNKNOWN_ORDER_STATUS"
+
+
+class CoinbaseOrderSide(StrEnum):
+    BUY = "BUY"
+    SELL = "SELL"
+    UNKNOWN = "UNKNOWN_ORDER_SIDE"
+
+
+class CoinbaseOrderType(StrEnum):
+    MARKET = "MARKET"
+    LIMIT = "LIMIT"
+    STOP = "STOP"
+    STOP_LIMIT = "STOP_LIMIT"
+    UNKNOWN = "UNKNOWN_ORDER_TYPE"
+
+
+class CoinbaseTimeInForce(StrEnum):
+    GTC = "GOOD_UNTIL_CANCELLED"
+    GTD = "GOOD_UNTIL_DATE_TIME"
+    IOC = "IMMEDIATE_OR_CANCEL"
+    FOK = "FILL_OR_KILL"
+
+
+class CoinbaseProductType(StrEnum):
+    SPOT = "SPOT"
+    FUTURE = "FUTURE"
+
+
+class CoinbaseGranularity(StrEnum):
+    ONE_MINUTE = "ONE_MINUTE"
+    FIVE_MINUTE = "FIVE_MINUTE"
+    FIFTEEN_MINUTE = "FIFTEEN_MINUTE"
+    ONE_HOUR = "ONE_HOUR"
+    SIX_HOUR = "SIX_HOUR"
+    ONE_DAY = "ONE_DAY"
+
+
+class CoinbaseWsChannel(StrEnum):
+    LEVEL2 = "level2"
+    MARKET_TRADES = "market_trades"
+    USER = "user"
+    CANDLES = "candles"
+    TICKER = "ticker"
+    STATUS = "status"
+
+
+class CoinbaseWsEventType(StrEnum):
+    SNAPSHOT = "snapshot"
+    UPDATE = "update"
+```
+
+- [ ] **Step 3: Run, pass, commit**
+```bash
+pixi run pytest tests/test_schemas_enums.py -v
+git add coinbase_connector/schemas/enums.py tests/test_schemas_enums.py
+git commit -m "feat(schemas): add Coinbase enum types"
+```
+
+### Task 3.2: REST response schemas — core models
+
+**Files:**
+- Create: `coinbase_connector/schemas/rest.py`
+- Test: `tests/test_schemas_rest.py`
+
+Focus on the models needed for MVP: Product, Account, Order, Fill, Candle, OrderBookLevel, plus their wrapper responses.
+
+- [ ] **Step 1: Capture or stub fixtures**
+
+Create `tests/fixtures/rest/` files with representative minimal JSON. If fixture recorder is deferred, hand-craft minimal JSON that exercises required fields:
+
+```bash
+mkdir -p tests/fixtures/rest
+```
+
+Create `tests/fixtures/rest/account.json`:
+```json
+{
+  "uuid": "00000000-0000-0000-0000-000000000001",
+  "name": "BTC Wallet",
+  "currency": "BTC",
+  "available_balance": {"value": "0.5", "currency": "BTC"},
+  "hold": {"value": "0.1", "currency": "BTC"},
+  "default": true,
+  "active": true,
+  "ready": true,
+  "type": "ACCOUNT_TYPE_CRYPTO"
+}
+```
+
+Create `tests/fixtures/rest/product.json`, `tests/fixtures/rest/order.json`, `tests/fixtures/rest/orderbook.json`, `tests/fixtures/rest/candles.json` similarly (sourced from `coinbase-advanced-py` SDK examples or archived connector tests).
+
+- [ ] **Step 2: Write failing test**
+
+```python
+# tests/test_schemas_rest.py
+import json
+from pathlib import Path
+import pytest
+
+from coinbase_connector.schemas.rest import (
+    Account, Balance, Product, Order, Fill, Candle, OrderBookLevel,
+    OrderBookResponse, ListAccountsResponse, ListProductsResponse,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "rest"
+
+
+def test_account_parses():
+    data = json.loads((FIXTURES / "account.json").read_text())
+    account = Account.model_validate(data)
+    assert account.currency == "BTC"
+    assert account.available_balance.value == "0.5"
+    assert account.available_balance.currency == "BTC"
+
+
+def test_product_parses():
+    data = json.loads((FIXTURES / "product.json").read_text())
+    product = Product.model_validate(data)
+    assert product.product_id
+
+
+# Repeat for each model
+```
+
+- [ ] **Step 3: Implement schemas (port from archived `cat_api_v3_response_types.py` with v2 migration)**
+
+```python
+# coinbase_connector/schemas/rest.py
+from __future__ import annotations
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from coinbase_connector.schemas.enums import (
+    CoinbaseOrderStatus, CoinbaseOrderSide, CoinbaseOrderType,
+    CoinbaseTimeInForce, CoinbaseGranularity,
+)
+
+
+class _FrozenBase(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+
+class Balance(_FrozenBase):
+    value: str
+    currency: str
+
+
+class Account(_FrozenBase):
+    uuid: str
+    name: str
+    currency: str
+    available_balance: Balance
+    hold: Balance
+    default: bool = False
+    active: bool = True
+    ready: bool = True
+    type: Optional[str] = None
+
+
+class ListAccountsResponse(_FrozenBase):
+    accounts: list[Account]
+    has_next: bool = False
+    cursor: Optional[str] = None
+    size: int = 0
+
+
+class MarketIOCConfig(_FrozenBase):
+    quote_size: Optional[str] = None
+    base_size: Optional[str] = None
+
+
+class LimitGTCConfig(_FrozenBase):
+    base_size: str
+    limit_price: str
+    post_only: bool = False
+
+
+class LimitGTDConfig(LimitGTCConfig):
+    end_time: datetime
+
+
+class StopLimitGTCConfig(_FrozenBase):
+    base_size: str
+    limit_price: str
+    stop_price: str
+    stop_direction: str
+
+
+class OrderConfiguration(_FrozenBase):
+    market_market_ioc: Optional[MarketIOCConfig] = None
+    limit_limit_gtc: Optional[LimitGTCConfig] = None
+    limit_limit_gtd: Optional[LimitGTDConfig] = None
+    stop_limit_stop_limit_gtc: Optional[StopLimitGTCConfig] = None
+
+
+class Order(_FrozenBase):
+    order_id: str
+    client_order_id: str
+    product_id: str
+    user_id: Optional[str] = None
+    order_configuration: Optional[OrderConfiguration] = None
+    side: CoinbaseOrderSide
+    status: CoinbaseOrderStatus
+    time_in_force: Optional[CoinbaseTimeInForce] = None
+    created_time: Optional[datetime] = None
+    filled_size: str = "0"
+    average_filled_price: str = "0"
+    total_fees: str = "0"
+    filled_value: str = "0"
+    completion_percentage: str = "0"
+    number_of_fills: str = "0"
+    pending_cancel: bool = False
+    settled: bool = False
+    reject_reason: Optional[str] = None
+    order_type: Optional[CoinbaseOrderType] = None
+
+
+class CreateOrderSuccess(_FrozenBase):
+    order_id: str
+    product_id: str
+    side: CoinbaseOrderSide
+    client_order_id: str
+
+
+class CreateOrderResponse(_FrozenBase):
+    success: bool
+    order_id: Optional[str] = None
+    failure_reason: Optional[str] = None
+    success_response: Optional[CreateOrderSuccess] = None
+
+
+class CancelOrderResult(_FrozenBase):
+    success: bool
+    failure_reason: Optional[str] = None
+    order_id: str
+
+
+class CancelOrdersResponse(_FrozenBase):
+    results: list[CancelOrderResult]
+
+
+class ListOrdersResponse(_FrozenBase):
+    orders: list[Order]
+    sequence: Optional[str] = None
+    has_next: bool = False
+    cursor: Optional[str] = None
+
+
+class Fill(_FrozenBase):
+    entry_id: str
+    trade_id: str
+    order_id: str
+    trade_time: datetime
+    trade_type: str
+    price: str
+    size: str
+    commission: str
+    product_id: str
+    liquidity_indicator: Optional[str] = None
+    side: CoinbaseOrderSide
+
+
+class ListFillsResponse(_FrozenBase):
+    fills: list[Fill]
+    cursor: Optional[str] = None
+
+
+class Product(_FrozenBase):
+    product_id: str
+    base_currency_id: str
+    quote_currency_id: str
+    base_increment: str
+    quote_increment: str
+    base_min_size: str
+    base_max_size: str
+    quote_min_size: str
+    quote_max_size: str
+    status: Optional[str] = None
+    trading_disabled: bool = False
+    is_disabled: bool = False
+    new: bool = False
+    cancel_only: bool = False
+    limit_only: bool = False
+    post_only: bool = False
+    auction_mode: bool = False
+    product_type: Optional[str] = None
+    price: Optional[str] = None
+    volume_24h: Optional[str] = Field(default=None, alias="volume_24h")
+
+
+class ListProductsResponse(_FrozenBase):
+    products: list[Product]
+    num_products: int = 0
+
+
+class Candle(_FrozenBase):
+    start: str  # Unix timestamp string
+    low: str
+    high: str
+    open: str
+    close: str
+    volume: str
+
+
+class GetProductCandlesResponse(_FrozenBase):
+    candles: list[Candle]
+
+
+class OrderBookLevel(_FrozenBase):
+    price: str
+    size: str
+
+
+class PriceBook(_FrozenBase):
+    product_id: str
+    bids: list[OrderBookLevel]
+    asks: list[OrderBookLevel]
+    time: Optional[datetime] = None
+
+
+class OrderBookResponse(_FrozenBase):
+    pricebook: PriceBook
+
+
+class ServerTimeResponse(_FrozenBase):
+    iso: str
+    epochSeconds: str
+    epochMillis: str
+```
+
+- [ ] **Step 4: Run, pass, commit**
+```bash
+pixi run pytest tests/test_schemas_rest.py -v
+git add coinbase_connector/schemas/rest.py tests/test_schemas_rest.py tests/fixtures/rest/
+git commit -m "feat(schemas): add REST response models with fixture validation"
+```
+
+### Task 3.3: WS message schemas
+
+**Files:**
+- Create: `coinbase_connector/schemas/ws.py`
+- Test: `tests/test_schemas_ws.py`
+
+- [ ] **Step 1: Hand-craft minimal WS fixtures**
+
+Create `tests/fixtures/ws/level2_snapshot.json`:
+```json
+{
+  "channel": "l2_data",
+  "client_id": "",
+  "timestamp": "2026-04-24T12:00:00Z",
+  "sequence_num": 0,
+  "events": [{
+    "type": "snapshot",
+    "product_id": "BTC-USD",
+    "updates": [
+      {"side": "bid", "event_time": "2026-04-24T12:00:00Z", "price_level": "50000.00", "new_quantity": "0.5"},
+      {"side": "offer", "event_time": "2026-04-24T12:00:00Z", "price_level": "50001.00", "new_quantity": "0.3"}
+    ]
+  }]
+}
+```
+
+Create `tests/fixtures/ws/market_trades.json`, `tests/fixtures/ws/user_order.json` similarly.
+
+- [ ] **Step 2: Write failing test**
+
+```python
+# tests/test_schemas_ws.py
+import json
+from pathlib import Path
+from coinbase_connector.schemas.ws import (
+    WsMessage, Level2Event, Level2Update, MarketTradesEvent, UserEvent,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "ws"
+
+
+def test_level2_snapshot_parses():
+    data = json.loads((FIXTURES / "level2_snapshot.json").read_text())
+    msg = WsMessage.model_validate(data)
+    assert msg.channel == "l2_data"
+    assert len(msg.events) == 1
+```
+
+- [ ] **Step 3: Implement**
+
+```python
+# coinbase_connector/schemas/ws.py
+from __future__ import annotations
+from typing import Any, Optional
+from pydantic import BaseModel, ConfigDict
+
+
+class _FrozenBase(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+
+class Level2Update(_FrozenBase):
+    side: str  # "bid" or "offer"
+    event_time: str
+    price_level: str
+    new_quantity: str
+
+
+class Level2Event(_FrozenBase):
+    type: str  # "snapshot" or "update"
+    product_id: str
+    updates: list[Level2Update]
+
+
+class MarketTrade(_FrozenBase):
+    trade_id: str
+    product_id: str
+    price: str
+    size: str
+    side: str
+    time: str
+
+
+class MarketTradesEvent(_FrozenBase):
+    type: str
+    trades: list[MarketTrade]
+
+
+class UserOrder(_FrozenBase):
+    order_id: str
+    client_order_id: str
+    product_id: str
+    cumulative_quantity: str
+    leaves_quantity: str
+    avg_price: str
+    total_fees: str
+    status: str
+    creation_time: str
+    order_side: str
+    order_type: Optional[str] = None
+
+
+class UserEvent(_FrozenBase):
+    type: str
+    orders: list[UserOrder]
+
+
+class WsMessage(_FrozenBase):
+    channel: str
+    client_id: str = ""
+    timestamp: str
+    sequence_num: int = 0
+    events: list[dict[str, Any]]  # Raw — parsed per-channel by dispatcher
+```
+
+- [ ] **Step 4: Run, pass, commit**
+```bash
+pixi run pytest tests/test_schemas_ws.py -v
+git add coinbase_connector/schemas/ws.py tests/test_schemas_ws.py tests/fixtures/ws/
+git commit -m "feat(schemas): add WS message models"
+```
+
+---
+
+## Phase 4: Converters
+
+### Task 4.1: Pair conversions
+
+**Files:**
+- Create: `coinbase_connector/converters.py`
+- Test: `tests/test_converters.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_converters.py
+from coinbase_connector.converters import to_exchange_pair, from_exchange_pair
+
+def test_to_exchange_pair_passthrough():
+    assert to_exchange_pair("BTC-USD") == "BTC-USD"
+
+def test_from_exchange_pair_passthrough():
+    assert from_exchange_pair("BTC-USD") == "BTC-USD"
+```
+
+- [ ] **Step 2: Implement**
+
+```python
+# coinbase_connector/converters.py
+from decimal import Decimal
+from market_connector.primitives import (
+    OpenOrder, OrderBookSnapshot, OrderBookUpdate, OrderType, TradeEvent, TradeType,
+)
+
+from coinbase_connector.schemas.rest import (
+    Account, Candle, Order, OrderBookResponse, PriceBook,
+)
+from coinbase_connector.schemas.ws import Level2Event, MarketTrade
+
+
+def to_exchange_pair(trading_pair: str) -> str:
+    return trading_pair
+
+def from_exchange_pair(product_id: str) -> str:
+    return product_id
+```
+
+### Task 4.2: Balance converter
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_converters.py (append)
+from coinbase_connector.converters import to_balance
+from coinbase_connector.schemas.rest import Account, Balance
+
+def test_to_balance_extracts_available():
+    account = Account(
+        uuid="u1", name="BTC Wallet", currency="BTC",
+        available_balance=Balance(value="1.5", currency="BTC"),
+        hold=Balance(value="0.3", currency="BTC"),
+    )
+    assert to_balance(account) == Decimal("1.5")
+```
+
+- [ ] **Step 2: Implement**
+
+```python
+# coinbase_connector/converters.py (append)
+def to_balance(account: Account) -> Decimal:
+    return Decimal(account.available_balance.value)
+```
+
+### Task 4.3: Order converter
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_converters.py (append)
+from coinbase_connector.converters import to_open_order
+from coinbase_connector.schemas.rest import Order, OrderConfiguration, LimitGTCConfig
+
+def test_to_open_order_from_limit():
+    order = Order(
+        order_id="o1", client_order_id="c1", product_id="BTC-USD",
+        side="BUY", status="OPEN",
+        order_configuration=OrderConfiguration(
+            limit_limit_gtc=LimitGTCConfig(base_size="0.5", limit_price="50000"),
+        ),
+        filled_size="0.1", average_filled_price="50000",
+    )
+    result = to_open_order(order)
+    assert result.exchange_order_id == "o1"
+    assert result.client_order_id == "c1"
+    assert result.trading_pair == "BTC-USD"
+    assert result.side == TradeType.BUY
+    assert result.amount == Decimal("0.5")
+    assert result.price == Decimal("50000")
+    assert result.filled_amount == Decimal("0.1")
+    assert result.order_type == OrderType.LIMIT
+```
+
+- [ ] **Step 2: Implement**
+
+```python
+# coinbase_connector/converters.py (append)
+_SIDE_MAP = {"BUY": TradeType.BUY, "SELL": TradeType.SELL}
+
+
+def _extract_order_details(cfg: OrderConfiguration) -> tuple[OrderType, Decimal, Decimal]:
+    """Returns (order_type, amount, price)."""
+    if cfg.limit_limit_gtc is not None:
+        c = cfg.limit_limit_gtc
+        ot = OrderType.LIMIT_MAKER if c.post_only else OrderType.LIMIT
+        return ot, Decimal(c.base_size), Decimal(c.limit_price)
+    if cfg.limit_limit_gtd is not None:
+        c = cfg.limit_limit_gtd
+        return OrderType.LIMIT, Decimal(c.base_size), Decimal(c.limit_price)
+    if cfg.market_market_ioc is not None:
+        c = cfg.market_market_ioc
+        size = c.base_size or c.quote_size or "0"
+        return OrderType.MARKET, Decimal(size), Decimal("0")
+    raise ValueError("Unsupported order configuration")
+
+
+def to_open_order(order: Order) -> OpenOrder:
+    ot, amount, price = _extract_order_details(order.order_configuration) \
+        if order.order_configuration else (OrderType.LIMIT, Decimal("0"), Decimal("0"))
+
+    return OpenOrder(
+        client_order_id=order.client_order_id,
+        exchange_order_id=order.order_id,
+        trading_pair=from_exchange_pair(order.product_id),
+        order_type=ot,
+        side=_SIDE_MAP[order.side.value],
+        amount=amount,
+        price=price,
+        filled_amount=Decimal(order.filled_size),
+        status=order.status.value,
+    )
+```
+
+### Task 4.4: Orderbook converters
+
+- [ ] **Step 1: Tests**
+
+```python
+# tests/test_converters.py (append)
+from coinbase_connector.converters import to_orderbook_snapshot, to_orderbook_update
+from coinbase_connector.schemas.rest import OrderBookResponse, PriceBook, OrderBookLevel
+from coinbase_connector.schemas.ws import Level2Event, Level2Update
+
+
+def test_to_orderbook_snapshot():
+    book = OrderBookResponse(pricebook=PriceBook(
+        product_id="BTC-USD",
+        bids=[OrderBookLevel(price="50000", size="0.5")],
+        asks=[OrderBookLevel(price="50001", size="0.3")],
+    ))
+    snap = to_orderbook_snapshot(book)
+    assert snap.trading_pair == "BTC-USD"
+    assert snap.bids == [(Decimal("50000"), Decimal("0.5"))]
+    assert snap.asks == [(Decimal("50001"), Decimal("0.3"))]
+
+
+def test_to_orderbook_update():
+    evt = Level2Event(
+        type="update", product_id="BTC-USD",
+        updates=[
+            Level2Update(side="bid", event_time="t", price_level="50000", new_quantity="0.5"),
+            Level2Update(side="offer", event_time="t", price_level="50001", new_quantity="0.3"),
+        ],
+    )
+    upd = to_orderbook_update(evt, update_id=42)
+    assert upd.trading_pair == "BTC-USD"
+    assert upd.bids == [(Decimal("50000"), Decimal("0.5"))]
+    assert upd.asks == [(Decimal("50001"), Decimal("0.3"))]
+    assert upd.update_id == 42
+```
+
+- [ ] **Step 2: Implement**
+
+```python
+# coinbase_connector/converters.py (append)
+def to_orderbook_snapshot(book: OrderBookResponse) -> OrderBookSnapshot:
+    pb = book.pricebook
+    return OrderBookSnapshot(
+        trading_pair=from_exchange_pair(pb.product_id),
+        bids=[(Decimal(l.price), Decimal(l.size)) for l in pb.bids],
+        asks=[(Decimal(l.price), Decimal(l.size)) for l in pb.asks],
+        timestamp=pb.time.timestamp() if pb.time else 0.0,
+    )
+
+
+def to_orderbook_update(event: Level2Event, update_id: int) -> OrderBookUpdate:
+    bids = [(Decimal(u.price_level), Decimal(u.new_quantity))
+            for u in event.updates if u.side == "bid"]
+    asks = [(Decimal(u.price_level), Decimal(u.new_quantity))
+            for u in event.updates if u.side == "offer"]
+    return OrderBookUpdate(
+        trading_pair=from_exchange_pair(event.product_id),
+        bids=bids,
+        asks=asks,
+        update_id=update_id,
+    )
+```
+
+### Task 4.5: Trade and candle converters
+
+- [ ] **Step 1: Tests**
+
+```python
+# tests/test_converters.py (append)
+from coinbase_connector.converters import to_trade_event, to_candle
+from coinbase_connector.schemas.ws import MarketTrade
+from coinbase_connector.schemas.rest import Candle
+
+
+def test_to_trade_event():
+    trade = MarketTrade(trade_id="t1", product_id="BTC-USD",
+                       price="50000", size="0.5", side="BUY",
+                       time="2026-04-24T12:00:00Z")
+    evt = to_trade_event(trade)
+    assert evt.exchange_trade_id == "t1"
+    assert evt.trading_pair == "BTC-USD"
+    assert evt.price == Decimal("50000")
+    assert evt.amount == Decimal("0.5")
+    assert evt.side == TradeType.BUY
+
+
+def test_to_candle_format():
+    candle = Candle(start="1714000000", low="49000", high="51000",
+                    open="50000", close="50500", volume="10.5")
+    result = to_candle(candle)
+    assert result == [1714000000, Decimal("50000"), Decimal("51000"),
+                      Decimal("49000"), Decimal("50500"), Decimal("10.5")]
+```
+
+- [ ] **Step 2: Implement + commit all converters**
+
+```python
+# coinbase_connector/converters.py (append)
+from datetime import datetime
+
+def to_trade_event(trade: MarketTrade) -> TradeEvent:
+    ts = datetime.fromisoformat(trade.time.replace("Z", "+00:00")).timestamp()
+    return TradeEvent(
+        exchange_trade_id=trade.trade_id,
+        trading_pair=from_exchange_pair(trade.product_id),
+        price=Decimal(trade.price),
+        amount=Decimal(trade.size),
+        side=_SIDE_MAP[trade.side],
+        timestamp=ts,
+    )
+
+
+def to_candle(candle: Candle) -> list:
+    return [
+        int(candle.start),
+        Decimal(candle.open),
+        Decimal(candle.high),
+        Decimal(candle.low),
+        Decimal(candle.close),
+        Decimal(candle.volume),
+    ]
+```
+
+```bash
+pixi run pytest tests/test_converters.py -v
+git add coinbase_connector/converters.py tests/test_converters.py
+git commit -m "feat(converters): add pure functions for schema→primitive conversion"
+```
+
+---
+
+## Phase 5: Mixin Protocols
+
+### Task 5.1: Protocol types
+
+**Files:**
+- Create: `coinbase_connector/mixins/protocols.py`
+
+- [ ] **Step 1: No test needed — these are type-only**
+
+- [ ] **Step 2: Implement**
+
+```python
+# coinbase_connector/mixins/protocols.py
+from __future__ import annotations
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from market_connector.transport.endpoint import Endpoint
+    from market_connector.transport.rest_base import RestConnectorBase, AuthCallable
+    from market_connector.transport.ws_base import WsConnectorBase
+    from coinbase_connector.config import CoinbaseConfig
+
+
+class HasRest(Protocol):
+    # CoinbaseRestClient is a subclass of RestConnectorBase, so declaring the base
+    # is sufficient for structural typing. Mixins only use .request() which is
+    # inherited unchanged.
+    _rest: RestConnectorBase
+
+
+class HasWs(Protocol):
+    _ws: WsConnectorBase
+
+
+class HasAuth(Protocol):
+    _auth: AuthCallable
+
+
+class HasEndpoints(Protocol):
+    _endpoints: dict[str, Endpoint]
+
+
+class HasConfig(Protocol):
+    _config: CoinbaseConfig
+
+
+class HasReady(Protocol):
+    @property
+    def ready(self) -> bool: ...
+```
+
+- [ ] **Step 3: Commit**
+```bash
+git add coinbase_connector/mixins/protocols.py
+git commit -m "feat(mixins): add Protocol types for self-typing across mixins"
+```
+
+---
+
+## Phase 6: Mixins (TDD per method)
+
+### Task 6.1: AccountsMixin — `get_balance`
+
+**Files:**
+- Create: `coinbase_connector/mixins/accounts.py`
+- Test: `tests/test_accounts_mixin.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_accounts_mixin.py
+import pytest
+from decimal import Decimal
+from market_connector.testing.mock_transport import MockRestClient
+from coinbase_connector.mixins.accounts import AccountsMixin
+
+
+class _TestableAccounts(AccountsMixin):
+    def __init__(self, rest):
+        self._rest = rest
+        self._endpoints = {}  # Not used by mock
+        self._started = True
+    @property
+    def ready(self) -> bool:
+        return self._started
+
+
+@pytest.mark.asyncio
+async def test_get_balance_finds_currency():
+    rest = MockRestClient()
+    rest.register("accounts", {
+        "accounts": [
+            {"uuid": "u1", "name": "BTC", "currency": "BTC",
+             "available_balance": {"value": "0.5", "currency": "BTC"},
+             "hold": {"value": "0", "currency": "BTC"}},
+            {"uuid": "u2", "name": "USD", "currency": "USD",
+             "available_balance": {"value": "1000", "currency": "USD"},
+             "hold": {"value": "0", "currency": "USD"}},
+        ],
+    })
+    mixin = _TestableAccounts(rest)
+    assert await mixin.get_balance("BTC") == Decimal("0.5")
+    assert await mixin.get_balance("USD") == Decimal("1000")
+
+
+@pytest.mark.asyncio
+async def test_get_balance_missing_currency_zero():
+    rest = MockRestClient()
+    rest.register("accounts", {"accounts": []})
+    mixin = _TestableAccounts(rest)
+    assert await mixin.get_balance("ETH") == Decimal("0")
+```
+
+- [ ] **Step 2: Implement**
+
+```python
+# coinbase_connector/mixins/accounts.py
+from __future__ import annotations
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from coinbase_connector.converters import to_balance
+from coinbase_connector.mixins.protocols import HasRest, HasReady
+from coinbase_connector.schemas.rest import ListAccountsResponse
+
+if TYPE_CHECKING:
+    pass
+
+
+class AccountsMixin:
+    async def get_balance(self: HasRest & HasReady, currency: str) -> Decimal:  # type: ignore[misc]
+        if not self.ready:
+            from market_connector.exceptions import GatewayNotStartedError
+            raise GatewayNotStartedError("Gateway not started")
+
+        raw = await self._rest.request("accounts")
+        response = ListAccountsResponse.model_validate(raw)
+        for account in response.accounts:
+            if account.currency == currency:
+                return to_balance(account)
+        return Decimal("0")
+```
+
+- [ ] **Step 3: Run, pass, commit**
+```bash
+pixi run pytest tests/test_accounts_mixin.py -v
+git add coinbase_connector/mixins/accounts.py tests/test_accounts_mixin.py
+git commit -m "feat(mixins): add AccountsMixin.get_balance"
+```
+
+### Task 6.2: MarketDataMixin — `get_orderbook`, `get_mid_price`, `get_candles`
+
+**Files:**
+- Create: `coinbase_connector/mixins/market_data.py`
+- Test: `tests/test_market_data_mixin.py`
+
+- [ ] **Step 1: Tests**
+
+```python
+# tests/test_market_data_mixin.py
+import pytest
+from decimal import Decimal
+from market_connector.testing.mock_transport import MockRestClient
+from coinbase_connector.mixins.market_data import MarketDataMixin
+
+
+class _TestableMarket(MarketDataMixin):
+    def __init__(self, rest):
+        self._rest = rest
+        self._endpoints = {}
+        self._started = True
+    @property
+    def ready(self) -> bool:
+        return self._started
+
+
+@pytest.mark.asyncio
+async def test_get_orderbook_parses_response():
+    rest = MockRestClient()
+    rest.register("product_book", {
+        "pricebook": {
+            "product_id": "BTC-USD",
+            "bids": [{"price": "50000", "size": "0.5"}],
+            "asks": [{"price": "50001", "size": "0.3"}],
+        },
+    })
+    mixin = _TestableMarket(rest)
+    book = await mixin.get_orderbook("BTC-USD")
+    assert book.trading_pair == "BTC-USD"
+    assert book.bids[0] == (Decimal("50000"), Decimal("0.5"))
+
+
+@pytest.mark.asyncio
+async def test_get_mid_price_computed_from_book():
+    rest = MockRestClient()
+    rest.register("product_book", {
+        "pricebook": {"product_id": "BTC-USD",
+                      "bids": [{"price": "50000", "size": "1"}],
+                      "asks": [{"price": "50002", "size": "1"}]},
+    })
+    mixin = _TestableMarket(rest)
+    assert await mixin.get_mid_price("BTC-USD") == Decimal("50001")
+
+
+@pytest.mark.asyncio
+async def test_get_candles_returns_list():
+    rest = MockRestClient()
+    rest.register("candles", {"candles": [
+        {"start": "1714000000", "low": "49000", "high": "51000",
+         "open": "50000", "close": "50500", "volume": "10"},
+    ]})
+    mixin = _TestableMarket(rest)
+    candles = await mixin.get_candles("BTC-USD", "ONE_HOUR", 100)
+    assert len(candles) == 1
+    assert candles[0][1] == Decimal("50000")  # open
+```
+
+- [ ] **Step 2: Implement**
+
+```python
+# coinbase_connector/mixins/market_data.py
+from __future__ import annotations
+from decimal import Decimal
+from market_connector.exceptions import GatewayNotStartedError
+
+from coinbase_connector.converters import (
+    to_candle, to_exchange_pair, to_orderbook_snapshot,
+)
+from coinbase_connector.mixins.protocols import HasReady, HasRest
+from coinbase_connector.schemas.rest import GetProductCandlesResponse, OrderBookResponse
+
+
+class MarketDataMixin:
+    async def get_orderbook(self: HasRest & HasReady, trading_pair: str):  # type: ignore[misc]
+        if not self.ready:
+            raise GatewayNotStartedError("Gateway not started")
+        product_id = to_exchange_pair(trading_pair)
+        raw = await self._rest.request("product_book", params={"product_id": product_id})
+        return to_orderbook_snapshot(OrderBookResponse.model_validate(raw))
+
+    async def get_mid_price(self: HasRest & HasReady, trading_pair: str) -> Decimal:  # type: ignore[misc]
+        book = await self.get_orderbook(trading_pair)  # type: ignore[misc]
+        if not book.bids or not book.asks:
+            return Decimal("0")
+        return (book.bids[0][0] + book.asks[0][0]) / 2
+
+    async def get_candles(self: HasRest & HasReady, trading_pair: str,
+                           interval: str, limit: int) -> list:  # type: ignore[misc]
+        if not self.ready:
+            raise GatewayNotStartedError("Gateway not started")
+        product_id = to_exchange_pair(trading_pair)
+        raw = await self._rest.request(
+            "candles",
+            params={"product_id": product_id, "granularity": interval, "limit": limit},
+        )
+        response = GetProductCandlesResponse.model_validate(raw)
+        return [to_candle(c) for c in response.candles]
+```
+
+- [ ] **Step 3: Run, pass, commit**
+```bash
+pixi run pytest tests/test_market_data_mixin.py -v
+git add coinbase_connector/mixins/market_data.py tests/test_market_data_mixin.py
+git commit -m "feat(mixins): add MarketDataMixin (orderbook, mid_price, candles)"
+```
+
+### Task 6.3: OrdersMixin — `place_order`, `cancel_order`, `get_open_orders`
+
+**Files:**
+- Create: `coinbase_connector/mixins/orders.py`
+- Test: `tests/test_orders_mixin.py`
+
+- [ ] **Step 1: Tests**
+
+```python
+# tests/test_orders_mixin.py
+import uuid
+import pytest
+from decimal import Decimal
+from market_connector.primitives import OrderType, TradeType
+from market_connector.testing.mock_transport import MockRestClient
+from coinbase_connector.mixins.orders import OrdersMixin
+
+
+class _TestableOrders(OrdersMixin):
+    def __init__(self, rest):
+        self._rest = rest
+        self._endpoints = {}
+        self._started = True
+    @property
+    def ready(self) -> bool:
+        return self._started
+
+
+@pytest.mark.asyncio
+async def test_place_limit_order():
+    rest = MockRestClient()
+    rest.register("place_order", {
+        "success": True, "order_id": "o1",
+        "success_response": {
+            "order_id": "o1", "product_id": "BTC-USD",
+            "side": "BUY", "client_order_id": "c1",
+        },
+    })
+    mixin = _TestableOrders(rest)
+    client_id = await mixin.place_order(
+        "BTC-USD", OrderType.LIMIT, TradeType.BUY, Decimal("0.5"), Decimal("50000"),
+    )
+    assert client_id == "c1"
+
+
+@pytest.mark.asyncio
+async def test_cancel_order_returns_true():
+    rest = MockRestClient()
+    rest.register("cancel_orders", {"results": [{"success": True, "order_id": "o1"}]})
+    mixin = _TestableOrders(rest)
+    assert await mixin.cancel_order("BTC-USD", "c1") is True
+
+
+@pytest.mark.asyncio
+async def test_get_open_orders_filters_by_pair():
+    rest = MockRestClient()
+    rest.register("list_orders", {"orders": [
+        {"order_id": "o1", "client_order_id": "c1", "product_id": "BTC-USD",
+         "side": "BUY", "status": "OPEN",
+         "order_configuration": {"limit_limit_gtc": {"base_size": "0.5", "limit_price": "50000"}},
+         "filled_size": "0", "average_filled_price": "0"},
+    ]})
+    mixin = _TestableOrders(rest)
+    orders = await mixin.get_open_orders("BTC-USD")
+    assert len(orders) == 1
+    assert orders[0].client_order_id == "c1"
+```
+
+- [ ] **Step 2: Implement**
+
+```python
+# coinbase_connector/mixins/orders.py
+from __future__ import annotations
+import uuid
+from decimal import Decimal
+from market_connector.exceptions import GatewayNotStartedError, OrderRejectedError
+from market_connector.primitives import OpenOrder, OrderType, TradeType
+
+from coinbase_connector.converters import to_exchange_pair, to_open_order
+from coinbase_connector.mixins.protocols import HasReady, HasRest
+from coinbase_connector.schemas.rest import (
+    CancelOrdersResponse, CreateOrderResponse, ListOrdersResponse,
+)
+
+
+def _build_order_config(order_type: OrderType, amount: Decimal, price: Decimal | None) -> dict:
+    base_size = str(amount)
+    if order_type == OrderType.LIMIT:
+        return {"limit_limit_gtc": {"base_size": base_size, "limit_price": str(price), "post_only": False}}
+    if order_type == OrderType.LIMIT_MAKER:
+        return {"limit_limit_gtc": {"base_size": base_size, "limit_price": str(price), "post_only": True}}
+    if order_type == OrderType.MARKET:
+        return {"market_market_ioc": {"base_size": base_size}}
+    raise ValueError(f"Unsupported order type: {order_type}")
+
+
+class OrdersMixin:
+    async def place_order(
+        self: HasRest & HasReady,  # type: ignore[misc]
+        trading_pair: str,
+        order_type: OrderType | str,
+        side: TradeType | str,
+        amount: Decimal,
+        price: Decimal | None,
+    ) -> str:
+        if not self.ready:
+            raise GatewayNotStartedError("Gateway not started")
+
+        client_id = f"coinbase-{uuid.uuid4()}"
+        cfg = _build_order_config(OrderType(order_type), amount, price)
+        body = {
+            "client_order_id": client_id,
+            "product_id": to_exchange_pair(trading_pair),
+            "side": side if isinstance(side, str) else side.value,
+            "order_configuration": cfg,
+        }
+        raw = await self._rest.request("place_order", data=body)
+        response = CreateOrderResponse.model_validate(raw)
+        if not response.success:
+            raise OrderRejectedError(response.failure_reason or "order rejected")
+        return client_id
+
+    async def cancel_order(self: HasRest & HasReady,  # type: ignore[misc]
+                            trading_pair: str, client_order_id: str) -> bool:
+        if not self.ready:
+            raise GatewayNotStartedError("Gateway not started")
+        # TODO: Coinbase /orders/batch_cancel expects exchange order IDs, not client_order_ids.
+        # Initial impl accepts the client_order_id directly for the simple case where the caller
+        # tracks the mapping. A follow-up task should add an in-memory map of
+        # client_order_id → exchange_order_id populated by place_order and consumed here.
+        raw = await self._rest.request("cancel_orders", data={"order_ids": [client_order_id]})
+        response = CancelOrdersResponse.model_validate(raw)
+        return all(r.success for r in response.results)
+
+    async def get_open_orders(self: HasRest & HasReady,  # type: ignore[misc]
+                               trading_pair: str) -> list[OpenOrder]:
+        if not self.ready:
+            raise GatewayNotStartedError("Gateway not started")
+        product_id = to_exchange_pair(trading_pair)
+        # Use list_orders (historical/batch) with status=OPEN filter — NOT order_status
+        # (order_status is /historical/{order_id} for single-order lookup).
+        raw = await self._rest.request(
+            "list_orders",
+            params={"product_id": product_id, "order_status": "OPEN"},
+        )
+        response = ListOrdersResponse.model_validate(raw)
+        return [to_open_order(o) for o in response.orders]
+```
+
+- [ ] **Step 3: Run, pass, commit**
+```bash
+pixi run pytest tests/test_orders_mixin.py -v
+git add coinbase_connector/mixins/orders.py tests/test_orders_mixin.py
+git commit -m "feat(mixins): add OrdersMixin (place, cancel, get_open_orders)"
+```
+
+### Task 6.4: SubscriptionsMixin — `subscribe_orderbook`, `subscribe_trades`
+
+**Files:**
+- Create: `coinbase_connector/mixins/subscriptions.py`
+- Test: `tests/test_subscriptions_mixin.py`
+
+- [ ] **Step 1: Tests**
+
+```python
+# tests/test_subscriptions_mixin.py
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from coinbase_connector.mixins.subscriptions import SubscriptionsMixin
+
+
+class _TestableSubs(SubscriptionsMixin):
+    def __init__(self, ws, rest=None):
+        self._ws = ws
+        self._rest = rest
+        self._started = True
+    @property
+    def ready(self) -> bool:
+        return self._started
+
+
+@pytest.mark.asyncio
+async def test_subscribe_trades_invokes_callback():
+    ws = MagicMock()
+    received: list = []
+    captured_cb = {}
+
+    async def subscribe(channel, callback):
+        captured_cb["cb"] = callback
+        sub = MagicMock()
+        sub.cancel = AsyncMock()
+        return sub
+    ws.subscribe = subscribe
+
+    mixin = _TestableSubs(ws)
+
+    async with await mixin.subscribe_trades("BTC-USD", received.append):
+        # Simulate WS message delivery
+        captured_cb["cb"]({
+            "events": [{
+                "type": "update",
+                "trades": [{"trade_id": "t1", "product_id": "BTC-USD",
+                            "price": "50000", "size": "0.5", "side": "BUY",
+                            "time": "2026-04-24T12:00:00Z"}],
+            }],
+        })
+
+    assert len(received) == 1
+    assert received[0].exchange_trade_id == "t1"
+```
+
+- [ ] **Step 2: Implement**
+
+```python
+# coinbase_connector/mixins/subscriptions.py
+from __future__ import annotations
+from collections.abc import Callable
+from contextlib import asynccontextmanager
+from typing import Any
+
+from market_connector.exceptions import GatewayNotStartedError
+from market_connector.primitives import OrderBookUpdate, TradeEvent
+
+from coinbase_connector.converters import (
+    to_exchange_pair, to_orderbook_snapshot, to_orderbook_update, to_trade_event,
+)
+from coinbase_connector.mixins.protocols import HasReady, HasRest, HasWs
+from coinbase_connector.schemas.ws import Level2Event, MarketTrade, MarketTradesEvent
+
+
+class SubscriptionsMixin:
+    async def subscribe_orderbook(
+        self: HasWs & HasRest & HasReady,  # type: ignore[misc]
+        trading_pair: str,
+        callback: Callable[[OrderBookUpdate], None],
+    ):
+        if not self.ready:
+            raise GatewayNotStartedError("Gateway not started")
+
+        product_id = to_exchange_pair(trading_pair)
+        update_id_counter = [0]
+
+        def _dispatch(msg: dict[str, Any]) -> None:
+            events = msg.get("events", [])
+            for evt in events:
+                if evt.get("product_id") != product_id:
+                    continue
+                level2_evt = Level2Event.model_validate(evt)
+                update_id_counter[0] += 1
+                callback(to_orderbook_update(level2_evt, update_id=update_id_counter[0]))
+
+        @asynccontextmanager
+        async def _ctx():
+            sub = await self._ws.subscribe(f"level2:{product_id}", _dispatch)
+            try:
+                yield sub
+            finally:
+                await sub.cancel()
+
+        return _ctx()
+
+    async def subscribe_trades(
+        self: HasWs & HasReady,  # type: ignore[misc]
+        trading_pair: str,
+        callback: Callable[[TradeEvent], None],
+    ):
+        if not self.ready:
+            raise GatewayNotStartedError("Gateway not started")
+
+        product_id = to_exchange_pair(trading_pair)
+
+        def _dispatch(msg: dict[str, Any]) -> None:
+            events = msg.get("events", [])
+            for evt in events:
+                mte = MarketTradesEvent.model_validate(evt)
+                for trade in mte.trades:
+                    if trade.product_id != product_id:
+                        continue
+                    callback(to_trade_event(trade))
+
+        @asynccontextmanager
+        async def _ctx():
+            sub = await self._ws.subscribe(f"market_trades:{product_id}", _dispatch)
+            try:
+                yield sub
+            finally:
+                await sub.cancel()
+
+        return _ctx()
+```
+
+- [ ] **Step 3: Run, pass, commit**
+```bash
+pixi run pytest tests/test_subscriptions_mixin.py -v
+git add coinbase_connector/mixins/subscriptions.py tests/test_subscriptions_mixin.py
+git commit -m "feat(mixins): add SubscriptionsMixin (orderbook + trades)"
+```
+
+---
+
+## Phase 7: CoinbaseGateway Composition Root
+
+### Task 7.1: Gateway __init__ and lifecycle
+
+**Files:**
+- Create: `coinbase_connector/coinbase_gateway.py`
+- Test: `tests/test_coinbase_gateway.py`
+
+- [ ] **Step 1: Tests**
+
+```python
+# tests/test_coinbase_gateway.py
+import pytest
+from decimal import Decimal
+from market_connector.exceptions import GatewayNotStartedError
+from coinbase_connector.coinbase_gateway import CoinbaseGateway
+from coinbase_connector.config import CoinbaseConfig
+
+
+@pytest.fixture
+def cfg():
+    return CoinbaseConfig(api_key="k", secret_key="raw_secret_hmac", sandbox=True)
+
+
+def test_gateway_initial_state_not_ready(cfg):
+    gw = CoinbaseGateway(cfg)
+    assert gw.ready is False
+
+
+@pytest.mark.asyncio
+async def test_pre_start_raises(cfg):
+    gw = CoinbaseGateway(cfg)
+    with pytest.raises(GatewayNotStartedError):
+        await gw.get_balance("USD")
+
+
+@pytest.mark.asyncio
+async def test_stop_is_idempotent(cfg):
+    gw = CoinbaseGateway(cfg)
+    await gw.stop()
+    await gw.stop()  # must not raise
+```
+
+- [ ] **Step 2: Implement**
+
+```python
+# coinbase_connector/coinbase_gateway.py
+from __future__ import annotations
+from market_connector.transport.ws_base import WsConnectorBase
+
+from coinbase_connector.auth import coinbase_auth
+from coinbase_connector.config import CoinbaseConfig
+from coinbase_connector.endpoints import ENDPOINT_REGISTRY
+from coinbase_connector.mixins.accounts import AccountsMixin
+from coinbase_connector.mixins.market_data import MarketDataMixin
+from coinbase_connector.mixins.orders import OrdersMixin
+from coinbase_connector.mixins.subscriptions import SubscriptionsMixin
+from coinbase_connector.transport import CoinbaseRestClient
+
+
+class CoinbaseGateway(OrdersMixin, AccountsMixin, MarketDataMixin, SubscriptionsMixin):
+    """Coinbase Advanced Trade gateway — implements ExchangeGateway protocol."""
+
+    def __init__(self, config: CoinbaseConfig):
+        self._config = config
+        self._auth = coinbase_auth(config.api_key, config.secret_key)  # context-taking signer
+        self._endpoints = ENDPOINT_REGISTRY
+        self._rest = CoinbaseRestClient(
+            base_url=config.base_url,
+            endpoints=ENDPOINT_REGISTRY,
+            signer=self._auth,  # wrapped with request context in subclass
+            max_retries=3,
+            retry_delay=1.0,
+        )
+        self._ws = WsConnectorBase(
+            url=config.ws_url,
+            auth=None,  # WS auth is injected into subscribe payload (see SubscriptionsMixin), not by framework
+            heartbeat_interval=30.0,
+            reconnect_delay=1.0,
+            max_reconnect_delay=60.0,
+        )
+        self._started = False
+
+    @property
+    def ready(self) -> bool:
+        return self._started
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        # Validate connectivity via server_time
+        await self._rest.request("server_time")
+        await self._ws.connect()
+        self._started = True
+
+    async def stop(self) -> None:
+        if not self._started:
+            return
+        await self._ws.disconnect()
+        await self._rest.close()
+        self._started = False
+```
+
+- [ ] **Step 3: Run, pass, commit**
+```bash
+pixi run pytest tests/test_coinbase_gateway.py -v
+git add coinbase_connector/coinbase_gateway.py tests/test_coinbase_gateway.py
+git commit -m "feat(gateway): add CoinbaseGateway composition root + lifecycle"
+```
+
+### Task 7.2: Public API exports
+
+**Files:**
+- Modify: `coinbase_connector/__init__.py`
+
+- [ ] **Step 1: Write**
+
+```python
+# coinbase_connector/__init__.py
+"""hb-coinbase-connector — Coinbase Advanced Trade gateway."""
+from coinbase_connector.coinbase_gateway import CoinbaseGateway
+from coinbase_connector.config import CoinbaseConfig
+
+__all__ = ["CoinbaseConfig", "CoinbaseGateway"]
+__version__ = "0.1.0"
+```
+
+- [ ] **Step 2: Commit**
+```bash
+git add coinbase_connector/__init__.py
+git commit -m "feat: expose CoinbaseGateway and CoinbaseConfig as public API"
+```
+
+---
+
+## Phase 8: Contract Tests
+
+### Task 8.1: GatewayContractTestBase subclass
+
+**Files:**
+- Create: `tests/test_contract.py`
+
+- [ ] **Step 1: Implement contract test subclass**
+
+```python
+# tests/test_contract.py
+"""Contract compliance tests — subclass of GatewayContractTestBase."""
+import pytest
+from market_connector.testing.contract import GatewayContractTestBase
+from market_connector.testing.mock_transport import MockRestClient, MockWsClient
+
+from coinbase_connector.coinbase_gateway import CoinbaseGateway
+from coinbase_connector.config import CoinbaseConfig
+
+
+class TestCoinbaseGatewayContract(GatewayContractTestBase):
+    @pytest.fixture
+    def gateway(self, monkeypatch):
+        mock_rest = MockRestClient()
+        # Pre-register all endpoints used by contract tests
+        mock_rest.register("server_time", {"iso": "2026-04-24T00:00:00Z",
+                                           "epochSeconds": "1714000000",
+                                           "epochMillis": "1714000000000"})
+        mock_rest.register("accounts", {"accounts": [
+            # Contract test calls get_balance("USDT") — register matching currency
+            {"uuid": "u", "name": "USDT", "currency": "USDT",
+             "available_balance": {"value": "1000", "currency": "USDT"},
+             "hold": {"value": "0", "currency": "USDT"}},
+        ]})
+        mock_rest.register("product_book", {"pricebook": {
+            "product_id": "BTC-USD",
+            "bids": [{"price": "50000", "size": "1"}],
+            "asks": [{"price": "50001", "size": "1"}],
+        }})
+        mock_rest.register("candles", {"candles": [
+            {"start": "1714000000", "low": "49000", "high": "51000",
+             "open": "50000", "close": "50500", "volume": "10"},
+        ]})
+        mock_rest.register("place_order", {"success": True, "order_id": "o1",
+                                            "success_response": {"order_id": "o1",
+                                                                 "product_id": "BTC-USD",
+                                                                 "side": "BUY",
+                                                                 "client_order_id": "c1"}})
+        mock_rest.register("cancel_orders", {"results": [{"success": True, "order_id": "o1"}]})
+        mock_rest.register("list_orders", {"orders": []})
+
+        mock_ws = MockWsClient()
+
+        cfg = CoinbaseConfig(api_key="k", secret_key="raw_hmac_secret", sandbox=True)
+        gw = CoinbaseGateway(cfg)
+        # Substitute transport
+        gw._rest = mock_rest
+        gw._ws = mock_ws
+
+        yield gw
+
+    @pytest.fixture
+    def trading_pair(self) -> str:
+        return "BTC-USD"
+```
+
+- [ ] **Step 2: Run, pass, commit**
+```bash
+pixi run pytest tests/test_contract.py -v
+# Expected: all inherited contract tests pass
+git add tests/test_contract.py
+git commit -m "test(contract): add GatewayContractTestBase subclass for CoinbaseGateway"
+```
+
+---
+
+## Phase 9: Fixture Recorder
+
+### Task 9.1: CLI for automated fixture capture
+
+**Files:**
+- Create: `coinbase_connector/tools/fixture_recorder.py`
+
+- [ ] **Step 1: Implement CLI tool**
+
+```python
+# coinbase_connector/tools/fixture_recorder.py
+"""
+Automated fixture capture for hb-coinbase-connector.
+
+Usage:
+    python -m coinbase_connector.tools.fixture_recorder \\
+        --api-key $KEY --secret $SECRET \\
+        --output tests/fixtures/ \\
+        --endpoints products,accounts,product_book,candles,server_time
+"""
+from __future__ import annotations
+import argparse
+import asyncio
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from coinbase_connector.config import CoinbaseConfig
+from coinbase_connector.coinbase_gateway import CoinbaseGateway
+
+
+_UUID_RE = re.compile(r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b")
+
+
+def sanitize(obj: Any) -> Any:
+    """Replace sensitive fields (UUIDs, API keys) with deterministic fakes."""
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            if k in {"api_key", "secret", "email", "user_id"}:
+                out[k] = f"REDACTED_{k.upper()}"
+            else:
+                out[k] = sanitize(v)
+        return out
+    if isinstance(obj, list):
+        return [sanitize(x) for x in obj]
+    if isinstance(obj, str) and _UUID_RE.search(obj):
+        return _UUID_RE.sub("00000000-0000-0000-0000-000000000001", obj)
+    return obj
+
+
+async def capture_rest(gw: CoinbaseGateway, endpoint: str, output_dir: Path) -> None:
+    # Map endpoint name → sample params
+    params_map = {
+        "server_time": {},
+        "accounts": {},
+        "products": {},
+        "product_book": {"product_id": "BTC-USD"},
+        "candles": {"product_id": "BTC-USD", "granularity": "ONE_HOUR"},
+        "order_status": {"order_status": "OPEN"},
+    }
+    try:
+        raw = await gw._rest.request(endpoint, params=params_map.get(endpoint, {}))
+        sanitized = sanitize(raw)
+        output_file = output_dir / f"{endpoint}.json"
+        output_file.write_text(json.dumps(sanitized, indent=2))
+        print(f"✓ Captured {endpoint} → {output_file}")
+    except Exception as e:
+        print(f"✗ Failed to capture {endpoint}: {e}")
+
+
+async def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--api-key", required=True)
+    parser.add_argument("--secret", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--endpoints", default="server_time,accounts,products,product_book,candles")
+    parser.add_argument("--sandbox", action="store_true")
+    args = parser.parse_args()
+
+    cfg = CoinbaseConfig(api_key=args.api_key, secret_key=args.secret, sandbox=args.sandbox)
+    gw = CoinbaseGateway(cfg)
+    await gw.start()
+
+    rest_dir = args.output / "rest"
+    rest_dir.mkdir(parents=True, exist_ok=True)
+
+    for ep in args.endpoints.split(","):
+        await capture_rest(gw, ep.strip(), rest_dir)
+
+    await gw.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+- [ ] **Step 2: Commit**
+```bash
+git add coinbase_connector/tools/fixture_recorder.py
+git commit -m "feat(tools): add fixture recorder CLI for automated API capture"
+```
+
+---
+
+## Phase 10: Final Integration
+
+### Task 10.1: Run full test suite and verify coverage
+
+- [ ] **Step 1: Full suite**
+```bash
+pixi run pytest -v --cov=coinbase_connector --cov-report=term-missing
+# Expected: >80% coverage, all tests pass
+```
+
+- [ ] **Step 2: Lint + typecheck**
+```bash
+pixi run lint
+pixi run typecheck
+```
+
+- [ ] **Step 3: Fix any issues surfaced by lint/typecheck**
+
+### Task 10.2: Wire submodule pointer update on ci-base
+
+**Files:**
+- Modify: `sub-packages/coinbase-connector` submodule pointer in parent repo
+
+- [ ] **Step 1: Commit changes in submodule first** (already done task-by-task)
+
+- [ ] **Step 2: Update parent repo's submodule pointer**
+```bash
+# In hummingbot parent repo
+cd /home/memento/PycharmProjects/Hummingbot/hummingbot
+git add sub-packages/coinbase-connector
+git commit -m "chore(submodule): update hb-coinbase-connector to initial implementation"
+```
+
+### Task 10.3: Create PR on hb-coinbase-connector
+
+- [ ] **Step 1: Push feature branch**
+```bash
+cd sub-packages/coinbase-connector
+git push -u origin feat/initial-implementation
+```
+
+- [ ] **Step 2: Create PR via gh**
+```bash
+gh pr create \\
+    --base main \\
+    --title "feat: initial hb-coinbase-connector implementation" \\
+    --body "Reference implementation of ExchangeGateway for Coinbase Advanced Trade.
+
+## Summary
+- Mixin-composed gateway (Orders, Accounts, MarketData, Subscriptions)
+- Full Pydantic v2 schemas + pure converter functions
+- JWT+HMAC auth extracted from in-tree connector
+- Automated fixture recorder
+- 4-tier test strategy with GatewayContractTestBase compliance
+
+## Design spec
+See docs/superpowers/specs/2026-04-24-coinbase-connector-design.md in parent repo."
+```
+
+---
+
+## Success Criteria
+
+- [ ] All tests pass: `pixi run pytest -v`
+- [ ] Coverage ≥ 80%: `pixi run pytest --cov=coinbase_connector`
+- [ ] Lint passes: `pixi run lint`
+- [ ] Typecheck passes: `pixi run typecheck`
+- [ ] Contract tests validate ExchangeGateway protocol compliance
+- [ ] CI green on hb-coinbase-connector PR
+- [ ] Submodule pointer updated on ci-base
+
+## Out of Scope (Deferred)
+
+- BeautifulSoup API doc scraper for schema validation (archived connector had this)
+- WS `user` channel subscription for real-time order status streaming
+- WS mechanics standardization in gateway framework (hybrid init as reusable component)
+- hb-candles-feed dependency inversion (consumer of gateway connectors)
+- `get_balance` caching with cross-mixin invalidation (can use simple TTL for now; advanced invalidation deferred)
+
+## References
+
+- **Design spec:** `docs/superpowers/specs/2026-04-24-coinbase-connector-design.md`
+- **Gateway framework:** `sub-packages/market-connector/market_connector/`
+- **In-tree connector (auth source):** `hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_auth.py`
+- **Archived connector (schemas source):** `~/PycharmProjects/Archives/HummingbotWorktree/Feat_coinbase_advanced_trading/hummingbot/connector/exchange/coinbase_advanced_trade/cat_data_types/`
+- **coinbase-advanced-py SDK** (reference, not a dependency): GitHub `coinbase/coinbase-advanced-py`

--- a/docs/superpowers/plans/2026-04-25-coinbase-connector-archive-manifest.md
+++ b/docs/superpowers/plans/2026-04-25-coinbase-connector-archive-manifest.md
@@ -1,0 +1,81 @@
+# hb-coinbase-connector Archive Manifest
+
+**Archived**: 2026-04-25
+**Source repo**: MementoRC/hb-coinbase-connector
+**Source branch**: feat/phase-10-integration
+**Archive tag**: archive/pre-merge-into-market-connector
+**HEAD commit**: cd21653d036b1ef566556ffced81a8a47abc4acc
+**Total commits**: 40
+**Time span**: 2026-04-24 15:20:40 (-0600) to 2026-04-25 15:47:00 (-0500)
+**Status of PR #1**: closed (CI green: tests 3.10/3.11/3.12, Quality, Audit, Build, security all pass; CodeQL neutral due to protocols.py:38 false-positive)
+
+This file preserves a one-line summary of every commit on `feat/phase-10-integration` before the migration to `hb-market-connector` rewrites paths via `git filter-repo`. Use the original SHAs (left column) to inspect any commit on the archive tag.
+
+---
+
+## Commit Manifest (newest first)
+
+| SHA (short) | Date | Subject |
+|---|---|---|
+| cd21653d | 2026-04-25 | fix(build): allow direct references in hatch metadata for git URL dep |
+| 726c6453 | 2026-04-25 | fix(ci): remove redundant security.yml, replace path dep with git URL, lower python floor |
+| 98fe237d | 2026-04-25 | test(phase-10): raise coverage to 98.8% — add missing branch tests |
+| bf46c5a1 | 2026-04-25 | fix(tools): import order in fixture_recorder (I001) |
+| a67ca52a | 2026-04-25 | feat(tools): add Coinbase fixture recorder CLI |
+| 3193b116 | 2026-04-25 | style: apply ruff lint+format cleanup across modules |
+| 2c42b448 | 2026-04-25 | test(contract): inherit hb-market-connector contract suite for CoinbaseGateway |
+| 4a3e50b8 | 2026-04-25 | feat(api): expose CoinbaseGateway and CoinbaseConfig as public package API |
+| 0c84f667 | 2026-04-25 | feat(gateway): compose CoinbaseGateway from mixins with auth/rest/ws orchestration |
+| 4cdf36da | 2026-04-25 | feat(mixins): add SubscriptionsMixin (subscribe_orderbook, subscribe_trades) |
+| 30de41e7 | 2026-04-25 | feat(mixins): add OrdersMixin (place, cancel, get_open_orders) |
+| 5d192e12 | 2026-04-25 | feat(mixins): add MarketDataMixin (orderbook, mid_price, candles) |
+| 87f1f943 | 2026-04-25 | feat(mixins): add AccountsMixin (get_balance) |
+| 21300d0c | 2026-04-25 | fix(typecheck): resolve mypy errors in auth.py and converters.py |
+| 2559bf3d | 2026-04-25 | feat(protocols): define mixin Protocol types for gateway composition |
+| cdb4eb23 | 2026-04-25 | refactor(converters): fix lint violations (F401 unused import, I001 import order) |
+| 35820736 | 2026-04-25 | feat(converters): add MarketTrade → TradeEvent and Candle → OHLCV list converters |
+| 557d8c07 | 2026-04-25 | feat(converters): add orderbook snapshot and incremental update converters |
+| cfc250ad | 2026-04-25 | feat(converters): add Coinbase Order → OpenOrder converter with order-type extraction |
+| 443d2963 | 2026-04-25 | feat(converters): add Account → available balance (Decimal) converter |
+| 60878e5e | 2026-04-25 | feat(converters): add pair passthrough converters (to/from_exchange_pair) |
+| 750fb1ec | 2026-04-25 | refactor(schemas): fix lint violations (UP045, N815, B017, E501) |
+| 9b174fd3 | 2026-04-25 | feat(schemas): add WS message models |
+| fed562d5 | 2026-04-25 | feat(schemas): add REST response models with fixture validation |
+| f82b33c8 | 2026-04-25 | feat(schemas): add Coinbase enum types |
+| 9bf85f4e | 2026-04-25 | fix(test): rename test_endpoint_is_Endpoint_type to lowercase (N802) |
+| c436f800 | 2026-04-25 | feat(config): add CoinbaseConfig with sandbox URL switching |
+| b6021ab9 | 2026-04-25 | feat(endpoints): add ENDPOINT_REGISTRY with per-endpoint rate limits |
+| 5a4e641b | 2026-04-25 | test(auth): add ES256 round-trip signature verification |
+| 2ae2a9ee | 2026-04-25 | fix(transport): enforce https:// in CoinbaseRestClient base_url |
+| e4e43ebf | 2026-04-25 | fix(auth): add aud=cdp claim to JWT for Coinbase CDP audience binding |
+| de0b73e7 | 2026-04-25 | fix(auth): apply ruff auto-fixes |
+| 93ba0bd6 | 2026-04-25 | feat(transport): step 5 — CoinbaseRestClient for context-aware signing |
+| b30743d3 | 2026-04-25 | feat(auth): step 4 — coinbase_auth() AuthCallable factory with JWT+HMAC dispatch |
+| a41d2592 | 2026-04-25 | feat(auth): step 3 — HMAC-SHA256 signer |
+| 19083260 | 2026-04-25 | feat(auth): step 2 — JWT builder (ES256, REST+WS variants) |
+| 797246f9 | 2026-04-25 | feat(auth): step 1 — PEM normalization for JWT key material |
+| 3b7c9d78 | 2026-04-24 | chore: scaffold hb-coinbase-connector package structure |
+| bf9f0a9d | 2026-04-24 | feat: initial scaffold for hb-coinbase-connector |
+| 6b7d370c | 2026-04-24 | Initial commit |
+
+## Recovery instructions
+
+To inspect the archive after migration:
+
+```
+git clone https://github.com/MementoRC/hb-coinbase-connector
+cd hb-coinbase-connector
+git checkout archive/pre-merge-into-market-connector
+git log --oneline
+```
+
+To re-extract any single file at any historical SHA:
+
+```
+git show <sha>:<original-path>
+# original-path uses pre-rewrite paths (coinbase_connector/..., tests/...)
+```
+
+After migration to hb-market-connector, the same content lives at:
+- `coinbase_connector/X` → `market_connector/exchanges/coinbase/X`
+- `tests/X` → `tests/exchanges/coinbase/X`

--- a/docs/superpowers/plans/2026-04-25-coinbase-merge-into-market-connector.md
+++ b/docs/superpowers/plans/2026-04-25-coinbase-merge-into-market-connector.md
@@ -1,0 +1,310 @@
+# Migration Plan: Merge hb-coinbase-connector into hb-market-connector
+
+**Date**: 2026-04-25
+**Author**: orchestrated via Claude Code
+**Status**: APPROVED — proceeding to Phase A
+**Supersedes**: PR #1 on MementoRC/hb-coinbase-connector
+**Related**: 2026-04-24-coinbase-connector-implementation.md
+
+---
+
+## 1. Motivation
+
+`hb-coinbase-connector` inherits rich behavior from `hb-market-connector` (`RestConnectorBase`, `WsConnectorBase`, primitives, exceptions, testing infrastructure). The hb_compat inversion-of-control pattern doesn't apply because:
+
+- Dependency direction is wrong (market-connector defines the contract, coinbase satisfies it)
+- Parents are rich behavior (TokenBucket, httpx, retry loops), not thin protocols
+
+The CI failures we just fought (path deps, git URL workaround, hatchling `allow-direct-references`, security.yml redundancy) are symptoms of an incorrect package boundary. coinbase-connector is not a sibling — it is a **plugin/specialization** of market-connector.
+
+Reference: ccxt, freqtrade, and similar multi-exchange libraries all ship exchanges as sub-packages of a single distribution, gated by optional-dependencies.
+
+## 2. Goal
+
+Move `coinbase_connector` Python package into `market_connector/exchanges/coinbase/`, ship as `pip install hb-market-connector[coinbase]`, archive `hb-coinbase-connector` repo, retire the parent submodule.
+
+**Out of scope** (deferred to future plans):
+- Adding additional exchanges (binance/kraken/okx) — establish the pattern first
+- Refactoring transport.py to inversion-of-control composition — orthogonal
+- Publishing hb-market-connector to PyPI/conda-forge — orthogonal
+
+## 3. Target Structure
+
+hb-market-connector/ (MementoRC/hb-market-connector)
+  market_connector/
+    transport/                            (existing — rest_base, ws_base, endpoint, token_bucket)
+    primitives.py                         (existing)
+    exceptions.py                         (existing)
+    testing/                              (existing — mock_transport, contract)
+    exchanges/                            (NEW)
+      __init__.py
+      coinbase/                           (moved from coinbase_connector/)
+        __init__.py
+        __about__.py                      (independent version: market-connector v0.X.Y, coinbase exchange v0.M.N)
+        auth.py
+        coinbase_gateway.py
+        config.py
+        converters.py
+        endpoints.py
+        transport.py
+        mixins/                           (entire dir)
+        schemas/                          (entire dir)
+        tools/                            (entire dir — fixture_recorder)
+  tests/
+    unit/                                 (existing market_connector tests)
+    exchanges/                            (NEW — house exchange-specific tests)
+      coinbase/
+        unit/                             (test_transport, test_auth, test_*_mixin, etc.)
+        conftest.py
+        test_contract.py
+    conftest.py                           (existing)
+  pyproject.toml
+    [project.optional-dependencies]
+    coinbase = ["pyjwt>=2.8", "cryptography>=41"]
+    dev      = [...]                      (existing — extended to test all exchanges)
+
+Import migration:
+- `from coinbase_connector.X` → `from market_connector.exchanges.coinbase.X`
+- `from market_connector.X` → unchanged (now intra-package)
+
+## 4. Phases
+
+### Phase A — Pre-migration audit (≈30 min)
+
+A.1 Verify no external consumers:
+- Confirm `coinbase_connector` is imported nowhere outside its own sub-package (already verified — only the bleed branch's docs and rate-oracle file reference the *name*, not imports).
+- Confirm no PRs/branches in flight on hb-coinbase-connector beyond `feat/phase-10-integration` (PR #1).
+
+A.2 Snapshot current state:
+- Tag `feat/phase-10-integration` HEAD on hb-coinbase-connector as `archive/pre-merge-into-market-connector` for rollback.
+- Save list of all commits on `feat/phase-10-integration` for credit preservation.
+
+A.3 History-preservation strategy (LOCKED DECISION)
+
+**SELECTED: A1 (git filter-repo)**
+
+Tool: Install via `pixi global install git-filter-repo` or `pip install git-filter-repo`
+
+Process: Each commit on hb-coinbase-connector is rewritten so all paths are prefixed with `market_connector/exchanges/coinbase/` (and tests prefixed similarly). Then merged via `git merge --allow-unrelated-histories` into hb-market-connector.
+
+Rationale: Clean history, full author/date preservation. Modest tooling cost. Most accurate for archeology.
+
+Alternative A2 (git subtree merge): Adds hb-coinbase-connector as a subtree. Trade-off: verbose merge commits, less ergonomic.
+
+Alternative A3 (squash + handcraft): Single squash + follow-up commits per area. Trade-off: loses individual attribution, worst for history.
+
+### Phase B — Code migration on hb-market-connector (≈2 hours)
+
+Branch: `feat/exchanges-coinbase` off `development`.
+
+B.1 Apply path rewrite (A1 strategy):
+```
+# In a temp clone of hb-coinbase-connector at feat/phase-10-integration:
+git filter-repo \
+  --path-rename coinbase_connector/:market_connector/exchanges/coinbase/ \
+  --path-rename tests/:tests/exchanges/coinbase/
+
+# Merge into hb-market-connector:
+cd ../hb-market-connector
+git remote add coinbase-archive ../hb-coinbase-connector
+git fetch coinbase-archive
+git checkout -b feat/exchanges-coinbase development
+git merge --allow-unrelated-histories coinbase-archive/feat/phase-10-integration
+git remote remove coinbase-archive
+```
+
+B.2 Resolve overlapping files (expected conflicts):
+- `pyproject.toml` — manual merge: keep market-connector's structure, fold in coinbase's deps as `[project.optional-dependencies] coinbase = [...]`, drop coinbase's hatch-version + entry-points if any.
+- `pixi.toml` — manual merge: fold coinbase deps into a `[feature.coinbase]` block, add `coinbase` env (and `coinbase-ci`).
+- `LICENSE`, `README.md`, `.gitignore`, `.release-please-config.json`, `.release-please-manifest.json`, `.github/workflows/*` — keep market-connector's; discard coinbase's duplicates.
+- `tests/conftest.py` — merge fixtures (root conftest stays the same; coinbase fixtures move under `tests/exchanges/coinbase/conftest.py`).
+
+B.3 Update imports across the rewritten coinbase files:
+- `from coinbase_connector.X` → `from market_connector.exchanges.coinbase.X`
+  - All 18 module files + 14 test files (per file inventory above).
+  - Use `Grep` + `Edit` (or a one-shot `sed -i` via `git mv`-style script).
+
+B.4 Update `market_connector/exchanges/coinbase/__init__.py` to re-export the public surface:
+```python
+from market_connector.exchanges.coinbase.coinbase_gateway import CoinbaseGateway
+from market_connector.exchanges.coinbase.config import CoinbaseConfig
+__all__ = ["CoinbaseGateway", "CoinbaseConfig"]
+```
+
+B.5 Add `market_connector/exchanges/__init__.py`:
+```python
+"""Exchange-specific connectors implementing market_connector protocols.
+
+Install with optional extras: `pip install hb-market-connector[coinbase]`.
+"""
+```
+
+### Phase C — Build/CI integration on hb-market-connector (≈1 hour)
+
+C.1 `pyproject.toml`:
+- Add `[project.optional-dependencies] coinbase = ["pyjwt>=2.8", "cryptography>=41"]`.
+- Extend `[tool.coverage.run] source_pkgs` to include `market_connector.exchanges.coinbase`.
+- Extend `[tool.ruff] include` / `[tool.mypy] files` if scoped explicitly.
+- Remove `[tool.hatch.metadata] allow-direct-references` (no longer needed; deps are now PyPI-pinned, not git URLs).
+
+C.2 `pixi.toml`:
+- Add `[feature.coinbase.dependencies]` with conda-forge equivalents (`pyjwt`, `cryptography`).
+- Add `coinbase = { features = ["coinbase", "dev"], solve-group = "default" }` env.
+- Extend `[feature.ci.dependencies]` to include `pyjwt`, `cryptography` so CI runs the coinbase tests.
+- Update `[tasks]`: extend `lint`/`format`/`test` paths to include `market_connector/exchanges` and `tests/exchanges`.
+
+C.3 CI workflow:
+- Existing `.github/workflows/ci.yml` (ci-framework reusable) auto-discovers via pixi. Verify by running locally.
+- No new workflows needed; matrix already covers 3.10/3.11/3.12.
+- Confirm `enable-hygiene-check: true` still passes (the new exchanges/ dir gets scanned).
+
+C.4 Local verification before pushing:
+```
+pixi install
+pixi run -e ci lint
+pixi run -e ci format-check
+pixi run -e ci typecheck
+pixi run -e ci test
+pixi run -e coinbase test                   # exchange-specific run
+```
+
+### Phase D — PR + review on hb-market-connector (≈1 day for review)
+
+D.1 Open PR `feat/exchanges-coinbase` → `development` with title:
+`feat(exchanges): add coinbase exchange connector (merge from hb-coinbase-connector)`
+
+D.2 PR description includes:
+- Link to this migration plan
+- Link to closed PR #1 on hb-coinbase-connector for archeology
+- Summary of the boundary-correction rationale
+- Test count delta (expected ~+150 tests)
+- Confirmation that all CI is green (Python 3.10/3.11/3.12, Quality, Audit, security scans)
+
+D.3 Once approved + merged:
+- Tag a release on hb-market-connector: minor version bump (e.g., `v0.2.0`) since this is a feature addition, not a breaking change.
+- Update `MementoRC/hb-market-connector` README to advertise `[coinbase]` extra.
+
+### Phase E — Retire hb-coinbase-connector repo (≈30 min)
+
+E.1 On `MementoRC/hb-coinbase-connector`:
+- Close PR #1 with comment linking to the merge PR on hb-market-connector and to this plan.
+- Tag `archive/pre-merge` (final state of feat/phase-10-integration).
+- Add a notice to README.md: "**This repository has been merged into [hb-market-connector](https://github.com/MementoRC/hb-market-connector) as `market_connector.exchanges.coinbase`. Install with `pip install hb-market-connector[coinbase]`. This repo is archived for historical reference.**"
+- Archive the repo via GitHub Settings → Archive.
+
+E.2 Do NOT delete the repo (preserves issue history, CodeQL alerts, prior CI runs).
+
+### Phase F — Update parent hummingbot repo (≈30 min)
+
+Branch on `MementoRC/hummingbot`: `chore/retire-coinbase-connector-submodule` off `ci-base`.
+
+F.1 Remove submodule:
+```
+git submodule deinit -f sub-packages/coinbase-connector
+git rm -f sub-packages/coinbase-connector
+rm -rf .git/modules/sub-packages/coinbase-connector
+```
+
+F.2 `.gitmodules`: ensure the `[submodule "sub-packages/coinbase-connector"]` block is gone.
+
+F.3 Hummingbot code audit completed (Task 3): Zero imports of `coinbase_connector` package found outside sub-packages/coinbase-connector/ itself. Candles and rate-oracle reference the *name* only, not the package. Status: CLEAN.
+
+F.4 Branch-tracking audit completed (Task 2):
+   - custom_git_setup/configs/branch-tracking.yaml: NO references to hb-coinbase-connector found.
+   - custom_git_setup/ directory scan: only test_history.json references (not config).
+   - hb-market-connector: No special config in branch-tracking.yaml (will be added post-integration).
+   - Action: No cleanup needed in branch-tracking.yaml before Phase F execution.
+
+F.5 Commit with message: `chore(submodule): retire hb-coinbase-connector — merged into hb-market-connector`. GPG-sign per project rule.
+
+F.6 Open PR on hummingbot — `chore/retire-coinbase-connector-submodule` → `ci-base`. After merge, the next bleeding-edge rebuild picks up the change automatically.
+
+## 5. Validation Checklist
+
+Pre-merge on hb-market-connector PR:
+- [ ] All ci-framework jobs green (Quality, Audit, CodeQL, Semgrep, Secrets, Scorecard, Hygiene, Detect Changes)
+- [ ] Test Python 3.10
+- [ ] Test Python 3.11
+- [ ] Test Python 3.12
+- [ ] Coverage >= existing market-connector baseline (no regression)
+- [ ] `pixi run -e coinbase test` runs the coinbase suite cleanly
+- [ ] `pixi run -e ci test` runs everything including coinbase
+- [ ] `pip install hb-market-connector` (no extras) does NOT pull pyjwt/cryptography
+- [ ] `pip install hb-market-connector[coinbase]` DOES pull pyjwt/cryptography
+- [ ] Importing `from market_connector.exchanges.coinbase import CoinbaseGateway` works
+- [ ] No leftover `coinbase_connector` import strings (grep returns 0)
+
+Post-merge:
+- [ ] Tag + release on hb-market-connector
+- [ ] PR #1 on hb-coinbase-connector closed with merge link
+- [ ] hb-coinbase-connector repo archived
+- [ ] hummingbot ci-base PR merged (submodule removed)
+- [ ] Bleeding-edge rebuild succeeds on next cron run
+
+## 6. Risk Register
+
+Risk: filter-repo path collision (file already exists in market-connector)
+  Likelihood: Low | Impact: Medium
+  Mitigation: Pre-check; only LICENSE/README/pyproject overlap, all handled in B.2
+
+Risk: Lost git-blame attribution
+  Likelihood: Low (with A1) / High (with A3) | Impact: Low
+  Mitigation: Use A1 strategy (filter-repo)
+
+Risk: Test ordering / fixture collisions when suites combine
+  Likelihood: Medium | Impact: Medium
+  Mitigation: Run `pixi run -e ci test --collect-only` first; verify no duplicate test IDs
+
+Risk: Pixi solver conflict between market-connector deps and coinbase JWT deps
+  Likelihood: Low | Impact: Low
+  Mitigation: Both are pure-python, no system-level conflicts expected
+
+Risk: Future hummingbot-side imports break (none currently)
+  Likelihood: Low | Impact: High
+  Mitigation: F.3 grep audit before submodule removal (COMPLETED)
+
+Risk: Someone has uncommitted work on the coinbase repo
+  Likelihood: User-known | Impact: High
+  Mitigation: User confirms before Phase A.2 archive tag
+
+Risk: CodeQL / Semgrep raise NEW alerts on the merged code
+  Likelihood: Medium | Impact: Low
+  Mitigation: Address in follow-up commit if any; the original PR #1 already had the protocols.py:38 false-positive
+
+## 7. Rollback
+
+Phase B–C reversible: revert the merge commit on hb-market-connector, drop the branch.
+
+Phase D reversible until PR merges: close the PR.
+
+Phase E reversible: un-archive the repo, reopen PR #1.
+
+Phase F reversible: revert the submodule-removal commit before bleeding-edge rebuild picks it up. After bleeding-edge rebuild, requires bleeding-edge fix-forward (re-add submodule pointing to archive tag).
+
+Total point of no return: Phase E (archive) + Phase F merge to ci-base. Up until then, every step is revertible.
+
+## 8. Effort Estimate
+
+| Phase | Effort | Can parallelize? |
+|-------|--------|------------------|
+| A. Pre-migration audit | 30 min | — |
+| B. Code migration | 2 hours | No (history rewrite + manual merges sequential) |
+| C. Build/CI integration | 1 hour | After B |
+| D. PR + review | 1 day calendar (~1 hour active) | — |
+| E. Retire hb-coinbase-connector | 30 min | After D |
+| F. Update hummingbot submodule | 30 min | Parallel with E |
+
+**Total active work**: ~5–6 hours over 1–2 days.
+
+## 9. Locked Decisions
+
+1. **History strategy**: git filter-repo (install via `pixi global install git-filter-repo` or `pip install git-filter-repo`)
+2. **Version bump**: minor bump on hb-market-connector (e.g., 0.1.x → 0.2.0)
+3. **Optional extras naming**: `[coinbase]` (matches dir, future binance becomes `[binance]`)
+4. **Tests location**: `tests/exchanges/coinbase/` mirroring source
+5. **Archival**: archive `hb-coinbase-connector` repo (do not delete)
+6. **Branch tracking**: No cleanup required — audit found zero references in branch-tracking.yaml to either hb-coinbase-connector or hb-market-connector.
+
+## 10. Status: APPROVED — Proceeding to Phase A
+
+Execution plan is locked. Proceed Phase A → F sequentially. No user input required.

--- a/docs/superpowers/specs/2026-04-24-coinbase-connector-design.md
+++ b/docs/superpowers/specs/2026-04-24-coinbase-connector-design.md
@@ -1,0 +1,357 @@
+# hb-coinbase-connector Design Spec
+
+**Date:** 2026-04-24
+**Status:** Draft
+**Repository:** MementoRC/hb-coinbase-connector
+**Submodule:** sub-packages/coinbase-connector
+
+## Overview
+
+Reference implementation of the `ExchangeGateway` protocol (from hb-market-connector) for the Coinbase Advanced Trade API. This connector demonstrates how exchange-specific code maps onto the gateway framework's transport layer, protocol contracts, and testing infrastructure.
+
+## Architecture
+
+**Approach:** Mixin inheritance with Protocol-typed `self` and gateway transport injection.
+
+`CoinbaseGateway` composes four domain-aligned mixins via multiple inheritance. Each mixin declares its dependencies through Protocol-typed `self` parameters (e.g., `self: HasRest & HasAuth`), eliminating the SuperCalls shim pattern used in the archived connector. The gateway class is a thin composition root — it wires transport, auth, and config but contains no business logic.
+
+**Data flow:**
+
+```
+Coinbase API (JSON) → Pydantic v2 schema models → pure converter functions → gateway primitives
+```
+
+The converter layer is the single boundary between exchange-specific and exchange-neutral types. Mixins call converters — they never touch raw JSON or construct primitives directly.
+
+**Key architectural properties:**
+- Structural subtyping: `CoinbaseGateway` satisfies `ExchangeGateway` protocol without inheriting from it
+- Transport injection: `RestConnectorBase` and `WsConnectorBase` from the gateway framework provide retry, reconnection, and rate limiting
+- Auth as callable: `AuthCallable = Callable[[dict], Awaitable[dict]]` — pure transformation, no transport awareness
+- Each mixin is independently testable via mock transport from the gateway framework
+
+## Package Structure
+
+```
+coinbase_connector/
+├── __init__.py                     # Public API: CoinbaseGateway, CoinbaseConfig
+├── coinbase_gateway.py             # Composition root — wires mixins + transport + lifecycle
+├── config.py                       # CoinbaseConfig (Pydantic v2: api_key, secret, sandbox flag)
+├── auth.py                         # coinbase_auth() → AuthCallable (JWT primary + HMAC fallback)
+├── endpoints.py                    # URL constants, endpoint registry, rate limit specs
+├── converters.py                   # Pure functions: schema models → gateway primitives
+│
+├── schemas/
+│   ├── __init__.py
+│   ├── rest.py                     # Pydantic v2 models for all REST responses
+│   ├── ws.py                       # Pydantic v2 models for all WS message types
+│   └── enums.py                    # Exchange-side enums (OrderStatus, ProductType, etc.)
+│
+├── mixins/
+│   ├── __init__.py
+│   ├── protocols.py                # Protocol types for self-typing across mixins
+│   ├── orders.py                   # OrdersMixin: place, cancel, get_open_orders
+│   ├── accounts.py                 # AccountsMixin: get_balance
+│   ├── market_data.py              # MarketDataMixin: orderbook, candles, mid_price
+│   └── subscriptions.py           # SubscriptionsMixin: subscribe_orderbook, subscribe_trades
+│
+├── tools/
+│   ├── __init__.py
+│   └── fixture_recorder.py        # Automated API response capture + sanitization
+│
+└── tests/
+    ├── __init__.py
+    ├── fixtures/                    # Captured JSON responses (REST + WS)
+    │   ├── rest/                    # products.json, orders.json, accounts.json, ...
+    │   └── ws/                     # level2.json, market_trades.json, user.json, ...
+    ├── test_schemas.py             # Tier 1: validate models against fixtures
+    ├── test_converters.py          # Tier 2: schema → primitive pure function tests
+    ├── test_auth.py                # Auth signing verification
+    ├── test_orders_mixin.py        # Tier 3: mock transport, order flow
+    ├── test_accounts_mixin.py
+    ├── test_market_data_mixin.py
+    ├── test_subscriptions_mixin.py
+    └── test_contract.py            # Tier 4: GatewayContractTestBase subclass
+```
+
+## Auth Module
+
+**File:** `auth.py`
+
+Exports a factory function:
+
+```python
+def coinbase_auth(api_key: str, secret_key: str) -> AuthCallable:
+```
+
+**JWT flow (primary):** Extracted from the existing `CoinbaseAdvancedTradeAuth` in hummingbot.
+- `_normalize_pem(secret_key)` — handles raw base64, single-line PEM, multi-line PEM → valid EC PEM
+- ES256 signing: `sub=api_key`, `iss="cdp"`, `kid=api_key`, random `nonce`, 120s expiry
+- REST: `uri` claim = `"METHOD api.coinbase.com/path"`, returns `{"Authorization": "Bearer <jwt>"}`
+- WS: no `uri` claim, returns `{"jwt": token}` for injection into subscribe payload
+
+**HMAC fallback:** Activated if PEM normalization fails.
+- `HMAC-SHA256(secret, timestamp + method + path + body)`
+- REST: returns `{"CB-ACCESS-KEY": ..., "CB-ACCESS-SIGN": ..., "CB-ACCESS-TIMESTAMP": ...}`
+- WS: returns `{"api_key": ..., "signature": ..., "timestamp": ...}`
+
+**WS auth caveat:** WS subscribe payloads inject auth fields into the message body (not HTTP headers). `SubscriptionsMixin` calls auth separately and merges the result into the subscribe JSON.
+
+**Dependencies:** `pyjwt`, `cryptography` (already in hummingbot's environment).
+
+**Reference:** `coinbase-advanced-py` SDK source used to validate signing logic — no runtime dependency.
+
+## Schemas
+
+**File:** `schemas/enums.py`, `schemas/rest.py`, `schemas/ws.py`
+
+Full Pydantic v2 coverage (`BaseModel` with `ConfigDict(frozen=True)`) for all consumed API types. Validated against `coinbase-advanced-py` source and captured fixtures.
+
+### Enums (`schemas/enums.py`)
+
+- `CoinbaseOrderStatus` — OPEN, FILLED, CANCELLED, PENDING, FAILED
+- `CoinbaseOrderType` — MARKET, LIMIT, LIMIT_MAKER, STOP_LIMIT
+- `CoinbaseSide` — BUY, SELL
+- `CoinbaseProductType` — SPOT, FUTURE
+- `CoinbaseGranularity` — ONE_MINUTE, FIVE_MINUTE, FIFTEEN_MINUTE, ONE_HOUR, SIX_HOUR, ONE_DAY
+- `CoinbaseWsChannel` — level2, market_trades, user, candles, ticker, status
+
+### REST Response Models (`schemas/rest.py`)
+
+| Model | Purpose | Key Fields |
+|-------|---------|------------|
+| `ProductResponse` / `Product` | Trading pair metadata | product_id, base/quote currency, price/size increments |
+| `AccountResponse` / `Account` | Balance info | uuid, currency, available_balance, hold |
+| `OrderResponse` / `Order` | Order lifecycle | order_id, client_order_id, status, side, type, filled_size, average_filled_price |
+| `FillResponse` / `Fill` | Trade fill details | trade_id, order_id, price, size, commission |
+| `CandleResponse` / `Candle` | OHLCV data | start, low, high, open, close, volume |
+| `OrderBookResponse` / `OrderBookLevel` | Book snapshot | bids/asks with price/size |
+| `ServerTimeResponse` | Time sync | iso, epochSeconds |
+| `TransactionSummaryResponse` | Fee tiers | fee_tier, total_volume |
+
+Each response model has a top-level wrapper matching the exact Coinbase JSON envelope.
+
+### WS Message Models (`schemas/ws.py`)
+
+| Model | Purpose | Key Fields |
+|-------|---------|------------|
+| `WsMessage` | Envelope | channel, client_id, timestamp, sequence_num, events |
+| `Level2Event` / `Level2Update` | Orderbook diffs | type (snapshot/update), side, price_level, new_quantity |
+| `MarketTradeEvent` / `MarketTrade` | Trade ticks | trade_id, side, price, size, time |
+| `UserEvent` / `UserOrder` | Order updates | order_id, status, filled_size, avg_price |
+| `CandleEvent` / `CandleUpdate` | Candle updates | start, low, high, open, close, volume |
+
+## Converters
+
+**File:** `converters.py`
+
+Pure functions, no state, no I/O. Each takes a schema model and returns a gateway primitive:
+
+| Function | Input | Output |
+|----------|-------|--------|
+| `to_open_order(order)` | `Order` | `OpenOrder` |
+| `to_trade_event(trade, trading_pair)` | `MarketTrade` | `TradeEvent` |
+| `to_orderbook_snapshot(book)` | `OrderBookResponse` | `OrderBookSnapshot` |
+| `to_orderbook_update(event)` | `Level2Event` | `OrderBookUpdate` |
+| `to_candle(candle)` | `Candle` | `list` — `[timestamp, open, high, low, close, volume]` matching gateway candle format |
+| `to_balance(account)` | `Account` | `Decimal` |
+| `to_exchange_pair(trading_pair)` | `str` | `str` (passthrough — Coinbase uses BTC-USD natively) |
+| `from_exchange_pair(product_id)` | `str` | `str` (passthrough) |
+
+The converter layer is the **only module** that imports both schema types and gateway primitives.
+
+## Mixins
+
+**File:** `mixins/protocols.py`, `mixins/orders.py`, `mixins/accounts.py`, `mixins/market_data.py`, `mixins/subscriptions.py`
+
+### Mixin Protocols (`mixins/protocols.py`)
+
+```python
+class HasRest(Protocol):
+    _rest: RestConnectorBase
+
+class HasWs(Protocol):
+    _ws: WsConnectorBase
+
+class HasAuth(Protocol):
+    _auth: AuthCallable
+
+class HasEndpoints(Protocol):
+    _endpoints: dict[str, Endpoint]  # gateway framework Endpoint type with rate limit fields
+
+class HasConfig(Protocol):
+    _config: CoinbaseConfig
+```
+
+Mixins combine these via intersection: `self: HasRest & HasAuth & HasEndpoints`.
+
+### OrdersMixin (`mixins/orders.py`)
+
+**Protocol methods:** `place_order`, `cancel_order`, `get_open_orders`
+
+- `place_order`: Builds Coinbase order configuration (LIMIT → `limit_limit_gtc`, MARKET → `market_market_ioc`, LIMIT_MAKER → `limit_limit_fok`), POSTs to `/brokerage/orders`, parses `OrderResponse`, returns `client_order_id`
+- `cancel_order`: POSTs to `/brokerage/orders/batch_cancel` with single order ID, returns success boolean
+- `get_open_orders`: GETs `/brokerage/orders` with status=OPEN filter, converts via `to_open_order()`
+
+### AccountsMixin (`mixins/accounts.py`)
+
+**Protocol methods:** `get_balance`
+
+- GETs `/brokerage/accounts`, finds account by currency, converts via `to_balance()`
+- Short TTL cache (30s) on account list to avoid repeated calls when checking multiple currencies; invalidated on any balance-affecting operation (order placement/cancellation)
+
+### MarketDataMixin (`mixins/market_data.py`)
+
+**Protocol methods:** `get_orderbook`, `get_candles`, `get_mid_price`
+
+- `get_orderbook`: GETs `/brokerage/product_book`, converts via `to_orderbook_snapshot()`
+- `get_candles`: GETs `/products/{id}/candles` with granularity mapping, converts via `to_candle()`
+- `get_mid_price`: Delegates to `get_orderbook()`, computes `(best_bid + best_ask) / 2`
+- All public endpoints — no auth required
+
+### SubscriptionsMixin (`mixins/subscriptions.py`)
+
+**Protocol methods:** `subscribe_orderbook`, `subscribe_trades`
+
+- `subscribe_orderbook`: Returns `AsyncContextManager` yielding `OrderBookUpdate` events. Subscribes to `level2` WS channel. First message treated as snapshot (hybrid init). Subsequent messages are deltas converted via `to_orderbook_update()` and delivered via callback. On reconnect: REST fallback via `get_orderbook()`. Sequence gap detection triggers re-sync. The context manager wraps a `Subscription` handle from `WsConnectorBase` — exiting the context cancels the subscription.
+- `subscribe_trades`: Returns `AsyncContextManager` yielding `TradeEvent` events. Subscribes to `market_trades` WS channel. Each message converted via `to_trade_event()` and delivered via callback. Context manager lifecycle mirrors `subscribe_orderbook`.
+- WS auth: injects auth fields into subscribe payload for authenticated channels
+
+**Return type contract:** Both subscription methods return `AsyncContextManager` as required by the `MarketDataGateway` protocol. The context manager's `__aenter__` establishes the WS subscription; `__aexit__` cancels it. This maps directly to `WsConnectorBase.subscribe()` which returns a `Subscription` with a `cancel()` method.
+
+**Cross-mixin dependency:** `subscribe_orderbook` needs `HasWs` (streaming) and access to `get_orderbook` (REST fallback on reconnect). Resolved by requiring `HasRest` on `self` — the composed `CoinbaseGateway` provides both via `MarketDataMixin`.
+
+## CoinbaseGateway
+
+**File:** `coinbase_gateway.py`
+
+```python
+class CoinbaseGateway(OrdersMixin, AccountsMixin, MarketDataMixin, SubscriptionsMixin):
+    """Coinbase Advanced Trade gateway implementing ExchangeGateway protocol."""
+```
+
+**Composition root responsibilities:**
+- Creates `RestConnectorBase(base_url, endpoints, auth, max_retries=3, retry_delay=1.0)`
+- Creates `WsConnectorBase(ws_url, auth, heartbeat_interval=30, reconnect_delay=1.0, max_reconnect_delay=60)`
+- `start()`: validates connectivity via `GET /brokerage/time`, connects WS
+- `stop()`: disconnects WS (auto-cancels subscriptions), idempotent
+- `ready` property: returns `self._started`
+- Pre-start guard: all mixin methods check `self.ready`, raise `GatewayNotStartedError` if false
+
+## CoinbaseConfig
+
+**File:** `config.py`
+
+```python
+class CoinbaseConfig(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    api_key: str
+    secret_key: str
+    sandbox: bool = False
+
+    # Computed: base_url, ws_url (sandbox vs production)
+```
+
+**URLs:**
+- Production REST: `https://api.coinbase.com/api/v3`
+- Production WS: `wss://advanced-trade-ws.coinbase.com`
+- Sandbox REST: `https://api-sandbox.coinbase.com/api/v3`
+- Sandbox WS: `wss://advanced-trade-ws-sandbox.coinbase.com`
+
+## Endpoints
+
+**File:** `endpoints.py`
+
+```python
+# Uses the gateway framework's Endpoint type which embeds rate limit params per-endpoint
+ENDPOINT_REGISTRY: dict[str, Endpoint] = {
+    "server_time":    Endpoint(path="/brokerage/time", limit=10, window=1),
+    "products":       Endpoint(path="/brokerage/market/products", limit=10, window=1),
+    "product_book":   Endpoint(path="/brokerage/product_book", limit=10, window=1),
+    "candles":        Endpoint(path="/brokerage/market/products/{product_id}/candles", limit=10, window=1),
+    "accounts":       Endpoint(path="/brokerage/accounts", limit=30, window=1),
+    "place_order":    Endpoint(path="/brokerage/orders", limit=30, window=1),
+    "cancel_orders":  Endpoint(path="/brokerage/orders/batch_cancel", limit=30, window=1),
+    "order_status":   Endpoint(path="/brokerage/orders/historical/{order_id}", limit=30, window=1),
+    "order_fills":    Endpoint(path="/brokerage/orders/historical/fills", limit=30, window=1),
+    "fee_summary":    Endpoint(path="/brokerage/transaction_summary", limit=30, window=1),
+}
+# Public endpoints: 10 req/s, Private endpoints: 30 req/s (embedded in Endpoint objects)
+```
+
+## Error Handling
+
+**Error mapping (single `_handle_error()` utility function):**
+
+| Coinbase Response | Gateway Exception |
+|---|---|
+| 401 Unauthorized | `AuthenticationError` |
+| 429 Too Many Requests | `RateLimitError` |
+| 400 + INVALID_ORDER / insufficient funds | `OrderRejectedError` |
+| 404 + order not found | `OrderNotFoundError` |
+| 503 / connection timeout / WS disconnect | `ExchangeUnavailableError` |
+
+**Rate limiting:** Leverages `RestConnectorBase` built-in retry with exponential backoff. `RATE_LIMITS` dict annotates endpoint pool membership. On 429 after retries exhausted, `RateLimitError` propagates.
+
+**WS resilience:** `WsConnectorBase` auto-reconnects with exponential backoff (max 60s). `SubscriptionsMixin` adds:
+- Re-subscribe with fresh auth on reconnect
+- Orderbook REST snapshot fallback on reconnect
+- Sequence gap detection → REST re-sync
+
+## Testing Strategy
+
+### Tier 1 — Schema Tests (`test_schemas.py`)
+Load fixture JSON → `Model.model_validate(fixture)` → assert field types/values. Catches API drift.
+
+### Tier 2 — Converter Tests (`test_converters.py`)
+Construct schema instances → call converter → assert gateway primitive fields. Pure functions, no I/O. Edge cases: empty orderbook, zero balance, partial fills, unknown status.
+
+### Tier 3 — Mixin Tests (`test_*_mixin.py`)
+Minimal test class inheriting single mixin + `MockRestClient`/`MockWsClient` from gateway framework. Register fixture responses → call mixin method → assert converter output. ~5-10 tests per mixin.
+
+### Tier 4 — Contract Tests (`test_contract.py`)
+Subclass `GatewayContractTestBase`, provide `gateway()` and `trading_pair()` fixtures. Inherits all protocol compliance tests (lifecycle, execution, market data). Mock transport — no real API calls.
+
+### Fixture Recorder (`tools/fixture_recorder.py`)
+
+CLI tool for automated fixture capture:
+
+```bash
+python -m coinbase_connector.tools.fixture_recorder \
+    --api-key $KEY --secret $SECRET \
+    --output tests/fixtures/ \
+    --endpoints products,accounts,product_book,candles,server_time
+```
+
+**Flow:** Authenticate → hit each endpoint → sanitize (replace account UUIDs, API keys; preserve market data) → write JSON fixtures. For WS: subscribe to channels for ~5 seconds, capture snapshot + deltas.
+
+**Rerunnable:** Diff against previous fixtures to detect API changes.
+
+## Design Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Extract & adapt auth from in-tree connector | JWT/HMAC edge cases (PEM normalization, nonce) already solved |
+| 2 | `coinbase-advanced-py` as reference only | No runtime dependency; validates schema correctness |
+| 3 | Full Pydantic v2 schema coverage | Self-documenting, catches API drift, enables fixture-driven testing |
+| 4 | Reimplement candles in-connector | Basis for comparison; future dependency inversion for hb-candles-feed |
+| 5 | Hybrid orderbook init (WS snapshot + REST fallback) | Coinbase sends initial snapshot on subscribe; REST fallback for reconnection |
+| 6 | Automated fixture recorder | Rerunnable capture; manual capture is one-time and tedious |
+| 7 | 4 domain-aligned mixins | Proven granularity from archived connector; independently testable |
+| 8 | Protocol flexibility | Revise gateway protocol when connector reveals better boundaries |
+| 9 | Full scope (all 12 methods) | Archived connector provides complete reference; gateway contracts are well-defined |
+
+## Future Work (Out of Scope)
+
+- **BeautifulSoup API doc scraper:** Live validation of Pydantic models against Coinbase web documentation (archived connector had this — noted for future)
+- **WS mechanics standardization:** Extract hybrid orderbook init pattern into reusable gateway framework component
+- **hb-candles-feed dependency inversion:** Once connector candles are proven, hb-candles-feed could consume this connector instead of reimplementing
+- **User channel (order status streaming):** WS `user` channel for real-time order updates — additive after initial implementation
+
+## References
+
+- **Gateway framework:** `sub-packages/market-connector/market_connector/` — protocols, primitives, transport, contract tests
+- **Existing in-tree connector:** `hummingbot/connector/exchange/coinbase_advanced_trade/` — auth, API patterns
+- **Archived connector:** `~/PycharmProjects/Archives/HummingbotWorktree/Feat_coinbase_advanced_trading/hummingbot/connector/exchange/coinbase_advanced_trade/` — mixin composition, Pydantic schemas, protocol-typed self
+- **Candles adapter:** `sub-packages/candles-feed/candles_feed/adapters/coinbase_advanced_trade/` — REST/WS candle patterns
+- **Protocol-typed self reference:** `dev/trailing_stop_strategy` branch — superior to NotImplementedError templates


### PR DESCRIPTION
## Summary

Lands 4 documentation files capturing the lifecycle of `hb-coinbase-connector`: its original design and implementation plan, plus the migration plan and archive manifest for retiring it in favor of integration into `hb-market-connector`.

No code changes. No submodule operations. The `sub-packages/coinbase-connector` submodule was never pushed to `origin/ci-base`; its content has already been merged into [hb-market-connector PR #11](https://github.com/MementoRC/hb-market-connector/pull/11) under `market_connector/exchanges/coinbase/`. The source repo MementoRC/hb-coinbase-connector is archived (read-only).

## Commits (3, all GPG-Verified)

1. `552e9b6d7` — docs: add hb-coinbase-connector design spec (cherry-picked from local ci-base, originally 2026-04-24)
2. `5775762a9` — docs: add hb-coinbase-connector implementation plan (cherry-picked from local ci-base, originally 2026-04-24)
3. `efa86190` — docs: add coinbase→market-connector migration plan and archive manifest (new, 2026-04-25)

## Files added

- `docs/superpowers/specs/2026-04-24-coinbase-connector-design.md`
- `docs/superpowers/plans/2026-04-24-coinbase-connector-implementation.md`
- `docs/superpowers/plans/2026-04-25-coinbase-merge-into-market-connector.md`
- `docs/superpowers/plans/2026-04-25-coinbase-connector-archive-manifest.md`

## Rationale

`hb-coinbase-connector` was a *specialization* of `hb-market-connector` (rich behavioral inheritance from `RestConnectorBase`, `WsConnectorBase`, primitives, exceptions, testing infrastructure), not a sibling sub-package. The `hb_compat` inversion-of-control pattern doesn't apply because:
- Dependency direction is wrong (market-connector defines the contract, coinbase satisfies it)
- Parents are rich behavior (TokenBucket, httpx, retry loops), not thin protocols

Mirrors ccxt / freqtrade multi-exchange layouts. See [`2026-04-25-coinbase-merge-into-market-connector.md`](docs/superpowers/plans/2026-04-25-coinbase-merge-into-market-connector.md) for the full reasoning, locked decisions, and 6-phase execution record.

## Earlier draft scope (informational)

A prior version of this PR included transient `add submodule` + `remove submodule` commits to preserve the on-disk story arc. That branch couldn't be cleanly rebased: `origin/ci-base` had absorbed the upstream PR #8193 fix via a different sync path, producing duplicate-commit conflicts when applying the local commits. Since the submodule never reached `origin/ci-base`, its retirement requires no commit here — the docs alone tell the story, and any local-only branch state will resolve at the next `hummingbot-branch-tracking.sh` rebuild.

## Cross-PR coordination

- [hb-market-connector PR #11](https://github.com/MementoRC/hb-market-connector/pull/11) holds the actual code merge. Merging that PR is what makes `pip install hb-market-connector[coinbase]` work.
- This PR is independent and can land before or after PR #11; only the bleeding-edge rebuild needs both states for a smooth pickup.

## Test Plan

Documentation-only change. CI green expected (no code touched).