### PR TITLE
fix(ci): forward-port workflow.yml from _for_bleed/* to ci-base

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,13 +2,13 @@ name: ci
 
 on:
   push:
-    branches: [master, development, 'refactor/unit_tests**', 'epic/**', '_for_bleed/**', '_for_bleed_manual/**']
+    branches: [master, development, 'refactor/unit_tests**', 'epic/**', 'ci-base', 'bleeding-edge', '_for_bleed/**', '_for_bleed_manual/**']
   pull_request:
     branches: [master, development, 'refactor/unit_tests**', 'epic/**', ci-base]
     types: [ready_for_review, opened, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Forward-port two workflow.yml hunks from `_for_bleed/*` branches (where they were misplaced per skill rule) to ci-base (their rightful home).

## Hunks

1. `push.branches` += `['ci-base', 'bleeding-edge']`
2. `concurrency.group` simplified

## Why now

PR #26 merged into ci-base, but the 15 tracked `_for_bleed/` branches each carry an identical workflow.yml delta from before. The next bleeding-edge rebuild aborts on `.github/` logical-conflict gate for every one of them. Promoting these hunks to ci-base where they belong removes the conflict for all 15 branches at once.

## Follow-up

After merge, mechanically strip workflow.yml from each `_for_bleed/*` branch via `git checkout ci-base -- .github/workflows/workflow.yml` + GPG-signed commit per branch. Tracked separately.

## Summary by Sourcery

Forward-port CI workflow configuration changes from bleed-specific branches into the shared ci-base workflow.

Build:
- Update the CI workflow push trigger branches to include ci-base and bleeding-edge.
- Simplify the concurrency group key to use only the workflow name and Git ref.