### PR TITLE
fix(ci): add sub-package build backends to pixi deps

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -68,6 +68,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ecdsa-0.19.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ecpy-1.2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ed25519-blake2b-1.4.1-py312h4c3975b_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eip712-0.3.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eth-abi-5.2.0-pyhd8ed1ab_0.conda
@@ -107,6 +108,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.2.1-h6083320_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.29.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hdwallets-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hexbytes-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
@@ -305,6 +307,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2026.4.28.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-deprecated-1.3.1.20260130-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.31.0.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-setuptools-82.0.0.20260210-pyhcf101f3_0.conda
@@ -415,6 +418,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ecdsa-0.19.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ecpy-1.2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ed25519-blake2b-1.4.1-py312h4c3975b_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eip712-0.3.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eth-abi-5.2.0-pyhd8ed1ab_0.conda
@@ -452,6 +456,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.2.1-h6083320_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.29.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hdwallets-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hexbytes-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
@@ -636,6 +641,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2026.4.28.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-deprecated-1.3.1.20260130-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.31.0.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-urllib3-1.26.25.14-pyhd8ed1ab_1.conda
@@ -1545,6 +1551,16 @@ packages:
   - pkg:pypi/ed25519-blake2b?source=hash-mapping
   size: 782601
   timestamp: 1756325057425
+- conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.6-pyhcf101f3_0.conda
+  sha256: bb826ff403b8195467e7cd5f504bc14767b424dac27bb225508ca2c1852554b2
+  md5: 86b177231eecb011fe00e2117dbc3348
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 13160
+  timestamp: 1776172429816
 - conda: https://conda.anaconda.org/conda-forge/noarch/eip712-0.3.3-pyhd8ed1ab_0.conda
   sha256: cfd2e5c2b8bddba9b65509dd722a7fec890f038131079de11b30bd1b26862800
   md5: e1ad90ca2d073c3902daf1abc9af81c2
@@ -2126,6 +2142,22 @@ packages:
   purls: []
   size: 2384060
   timestamp: 1774276284520
+- conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.29.0-pyhcf101f3_0.conda
+  sha256: bb86ff4ca54a2a0f63714766c7653a772c13d34c9e7cfb7be653db2fb806f961
+  md5: 9d67ecd4cd5e6a9be36522be95951785
+  depends:
+  - packaging >=24.2
+  - pathspec >=0.10.1
+  - pluggy >=1.0.0
+  - python >=3.10
+  - tomli >=1.2.2
+  - trove-classifiers
+  - editables >=0.3
+  - python
+  license: MIT
+  license_family: MIT
+  size: 61052
+  timestamp: 1773194193187
 - conda: https://conda.anaconda.org/conda-forge/noarch/hdwallets-0.1.2-pyhd8ed1ab_1.conda
   sha256: 00cbedaf462a2916301edb61c273279c87a53b881c37ec3ac326f67418262033
   md5: d7226ccf56e0a79317ba1412fa4e78a1
@@ -4826,6 +4858,15 @@ packages:
   - pkg:pypi/tqdm?source=compressed-mapping
   size: 94132
   timestamp: 1770153424136
+- conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2026.4.28.13-pyhd8ed1ab_0.conda
+  sha256: d8f62a784845800fc6b196b7b996757844238ab30438bc8db2ebc32b1132bb0d
+  md5: 3eea6839d5b20aa81c00a3c3e0fc3504
+  depends:
+  - python >=3.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 19926
+  timestamp: 1777392398253
 - conda: https://conda.anaconda.org/conda-forge/noarch/types-deprecated-1.3.1.20260130-pyhd8ed1ab_0.conda
   sha256: 91dfe121ea8b7dcb07fe835c91f1baef2fa4e9ea21b0aada984f1233805962bf
   md5: 4abf3f30806295659b8aa46cae1376c3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,11 @@ platforms = ["linux-64"]
 # Build/install
 python = ">=3.10.12,<3.13"
 cython = ">=3.0.12"
+hatchling = ">=1.29.0"
 maturin = ">=1.5"
-setuptools = ">=80.8.0"
 pip = ">=23.2.1"
+setuptools = ">=80.8.0"
+wheel = ">=0.37.0"
 # Core runtime
 aiohttp = ">=3.8.5"
 aioprocessing = ">=2.0.1"


### PR DESCRIPTION
## Problem

The `install-subpackages` pixi task installs all 7 sub-packages with `--no-build-isolation`, which requires the build backend to already be present in the pixi environment. Without `hatchling` in the env, pip raises `BackendUnavailable` when attempting to build editable installs of the sub-packages.

## Fix

Adds the union of `[build-system].requires` from all 7 sub-packages to `[tool.pixi.dependencies]`:

**Backends discovered per sub-package:**
- candles-feed: `hatchling>=1.18.0`, `Cython>=3`, `wheel>=0.37.0`
- liquidations-feed: `hatchling>=1.18.0`
- market-connector: `hatchling>=1.29.0`
- market-data: `hatchling>=1.29.0`
- market-simulator: `hatchling>=1.18.0`
- rate-oracle: `hatchling>=1.29.0`
- strategy-framework: `hatchling>=1.29.0`

**Union after deduplication:**
- `hatchling>=1.29.0` — NEW, from conda-forge
- `wheel>=0.37.0` — NEW, from conda-forge
- `cython>=3.0.12` — already present
- `setuptools>=80.8.0` — already present

**Added to `[tool.pixi.dependencies]` (Build/install section, alphabetical order):**
- `hatchling = ">=1.29.0"`
- `wheel = ">=0.37.0"`

## Validation

- `pixi install` — resolved successfully from conda-forge
- `pixi run install-subpackages` — all 7 packages installed editable, no `BackendUnavailable` errors
- `pixi run lint` — PASSED
- `pixi run format-check` — PASSED

## Summary by Sourcery

Build:
- Add hatchling and wheel to [tool.pixi.dependencies] so sub-packages can build without isolation using pixi tasks.