### PR TITLE
fix(ci): pin ruff to 0.15.7 + expand lint/format scope to controllers/scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ pytest-mock = "*"
 pytest-timeout = ">=2.1.0"
 coverage = ">=7.2.7"
 diff-cover = ">=7.7.0"
-ruff = "*"
+ruff = "==0.15.7"
 mypy = "*"
 pre-commit = ">=3.3.3"
 cython-lint = "*"
@@ -138,10 +138,10 @@ rust-build = { cmd = "maturin develop --manifest-path hummingbot/rust/Cargo.toml
 test = { cmd = "pytest test", depends-on = ["build"] }
 test-unit = { cmd = "pytest test/hummingbot", depends-on = ["build"] }
 test-fast = "pytest --timeout=30 --tb=short -q"
-lint = "ruff check hummingbot test"
+lint = "ruff check hummingbot test controllers scripts"
 lint-cython = "cython-lint hummingbot"
-format = "ruff format hummingbot test"
-format-check = "ruff format --check hummingbot test"
+format = "ruff format hummingbot test controllers scripts"
+format-check = "ruff format --check hummingbot test controllers scripts"
 type-check = "mypy hummingbot"
 security-scan = "bandit -c pyproject.toml -r hummingbot/"
 dependency-scan = { cmd = "pip-audit --strict --desc on", depends-on = ["install-dev"] }


### PR DESCRIPTION
## Summary

Two related fixes to align local pixi tasks with CI/pre-commit hooks.

## Change 1: Pin ruff version

**File**: `pyproject.toml` — `[tool.pixi.feature.dev.dependencies]`

Changed `ruff = "*"` to `ruff = "==0.15.7"` to match the `rev: v0.15.7` pin in `.pre-commit-config.yaml` (`astral-sh/ruff-pre-commit`).

Without this pin, `pixi` could resolve a newer ruff release and silently diverge from the pre-commit hook version. This causes CI runs where pre-commit uses 0.15.7 to reject code that `pixi run lint` accepted locally.

## Change 2: Expand lint/format scope

**File**: `pyproject.toml` — `[tool.pixi.tasks]`

Expanded `lint`, `format`, and `format-check` tasks from `hummingbot test` to `hummingbot test controllers scripts`.

The pre-commit ruff hooks already cover `controllers/` and `scripts/` via the repo-level exclude pattern (only `.pyx`/`.pxd` and `sub-packages/` are excluded). But the local pixi tasks didn't scan those directories. This created a gap: `pixi run lint` could be green locally while pre-commit flagged violations in `controllers/` or `scripts/`.

## Quality Gate Results

- `pixi run lint` — PASSED (0 violations, including controllers/ and scripts/)
- `pixi run format-check` — PASSED (1528 files already formatted)

Case A: No new violations surfaced by expanding scope. No auto-fix needed.

## Notes

- `pixi.lock` unchanged: ruff was already resolved to 0.15.7 in the existing lock.
- Per user memory: "ruff-pre-commit pinned to v0.15.7 (must match pixi version)" — this PR enforces that constraint in the manifest itself.