### PR TITLE
chore(ci-base): integrate hb-remote-iface sub-package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ ci = { features = ["ci", "dev"], solve-group = "default" }
 # py310/py311/py312 removed: pandas-ta/numba version conflicts
 
 [tool.pixi.tasks]
-install-subpackages = "python -m pip install --no-deps --no-build-isolation -e sub-packages/candles-feed -e sub-packages/liquidations-feed -e sub-packages/market-connector -e sub-packages/market-data -e sub-packages/market-simulator -e sub-packages/rate-oracle -e sub-packages/strategy-framework"
+install-subpackages = "python -m pip install --no-deps --no-build-isolation -e sub-packages/candles-feed -e sub-packages/liquidations-feed -e sub-packages/market-connector -e sub-packages/market-data -e sub-packages/market-simulator -e sub-packages/rate-oracle -e sub-packages/remote-iface -e sub-packages/strategy-framework"
 install-dev = { depends-on = ["install-subpackages"], cmd = "python -m pip install --no-deps --no-build-isolation -e ." }
 build = { cmd = "python setup.py build_ext --inplace", depends-on = ["install-dev"] }
 rust-build = { cmd = "maturin develop --manifest-path hummingbot/rust/Cargo.toml", depends-on = ["install-dev"] }


### PR DESCRIPTION
## Summary

Infrastructure-tier chore that wires the now-complete `hb-remote-iface` sub-package into the ci-base layer:

- Bumps `sub-packages/remote-iface` submodule pointer to `1e8bd97c` — tip of [MementoRC/hb-remote-iface](https://github.com/MementoRC/hb-remote-iface) `development` after Phase 4b lands (7 gateway components, 244 unit + integration tests, 91% coverage).
- Adds `-e sub-packages/remote-iface` to the `install-subpackages` pixi task in `pyproject.toml`, mirroring the existing pattern used by candles-feed, liquidations-feed, market-connector, market-data, market-simulator, rate-oracle, and strategy-framework.

No `pixi.toml` mirror needed — pixi config lives in `[tool.pixi.*]` of `pyproject.toml` and the sub-package install is task-driven (not a pixi dependency), so the lockfile is unaffected.

## Ownership split (per established model)

- **ci-base owns** (this PR): submodule pointer + dep declaration.
- **`_for_bleed/remote-iface-integration` owns** (separate branch, mirrors `_for_bleed/strategy-framework`): `hb_compat/remote_iface/adapter.py`, `create_gateway()` factory, callsite migration replacing `hummingbot.remote_iface.*`, deletion of `hummingbot/remote_iface/` + `test/hummingbot/remote_iface/` + `test/mock/mock_mqtt_server.py`, and the end-to-end smoke test. That work re-merges on each bleeding-edge rebuild cycle until the integration finalizes.

## Verification

- `pixi run lint` — PASS (no source files touched)
- `git status` — clean after commit (no lockfile drift, no untracked files)
- Commit `c8d245e9` GPG-signed (Verified, key `C7927B4C27159961`)
- Full `pixi install` / `pixi run install-subpackages` will execute in CI on this PR

## Test plan

- [ ] CI green on ci-base targeting checks
- [ ] `pixi run install-subpackages` succeeds (CI)
- [ ] Submodule pointer correctly resolves to `1e8bd97c` after clone+init

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Integrate the hb-remote-iface sub-package into the ci-base layer and ensure it is installed alongside existing sub-packages.

New Features:
- Add the hb-remote-iface sub-package to the install-subpackages pixi task so it is editable-installed with other sub-packages.

Enhancements:
- Update the remote-iface submodule reference to the latest revision for ci-base integration.