### PR TITLE
chore + fix: lockfile regen, market-connector bump, gateway review fix, cross-exchange MM race

### DIFF
--- a/hummingbot/client/command/gateway_swap_command.py
+++ b/hummingbot/client/command/gateway_swap_command.py
@@ -104,6 +104,10 @@ class GatewaySwapCommand:
             if side:
                 side = side.upper()
 
+            if side is not None and side not in ("BUY", "SELL"):
+                self.notify(f"Error: Invalid side '{side}'. Must be BUY or SELL.")
+                return
+
             # Construct trading pair
             trading_pair = f"{base_token}-{quote_token}"
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -3,8 +3,6 @@ environments:
   ci:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -351,8 +349,6 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda

--- a/test/hummingbot/strategy/cross_exchange_market_making/test_cross_exchange_market_making.py
+++ b/test/hummingbot/strategy/cross_exchange_market_making/test_cross_exchange_market_making.py
@@ -428,6 +428,7 @@ class HedgedMarketMakingUnitTest(unittest.TestCase):
         if len(self.maker_order_created_logger.event_log) == prev_maker_orders_created_len:
             self.async_run_with_timeout(self.maker_order_created_logger.wait_for(SellOrderCreatedEvent))
 
+        self.ev_loop.run_until_complete(asyncio.sleep(0.1))
         self.assertEqual(2, len(self.maker_cancel_order_logger.event_log))
         self.assertEqual(1, len(self.strategy_with_top_depth_tolerance.active_maker_bids))
         self.assertEqual(1, len(self.strategy_with_top_depth_tolerance.active_maker_asks))
@@ -485,6 +486,7 @@ class HedgedMarketMakingUnitTest(unittest.TestCase):
         if len(self.maker_order_created_logger.event_log) == prev_maker_orders_created_len:
             self.async_run_with_timeout(self.maker_order_created_logger.wait_for(SellOrderCreatedEvent))
 
+        self.ev_loop.run_until_complete(asyncio.sleep(0.1))
         self.assertEqual(2, len(self.maker_cancel_order_logger.event_log))
         self.assertEqual(1, len(self.strategy.active_maker_bids))
         self.assertEqual(1, len(self.strategy.active_maker_asks))


### PR DESCRIPTION
## Summary

Maintenance batch for `ci-base`. Replays the 4 still-valid commits from #33 onto current `ci-base` after PR #34 (remote-iface submodule registration) and PR #35 (remote-iface pointer bump to `7e725d5e`) made the original #33's remote-iface bump (`6477278a` Phase 2+3) obsolete. PR #33 will be closed in favor of this one.

## Commits (4)

1. **`chore(pixi)`** — regenerate lockfile (drops `pypi-prerelease-mode: if-necessary-or-explicit` no-op option from `ci` and `default` envs). No package version changes.
2. **`chore(submodule)`** — bump `sub-packages/market-connector` `06334bc6` → `4945877a`. Picks up 4 merged PRs on hb-market-connector `development`: Kraken Stage 5 (gateway + hb_compat), py312 pattern 1 (`@override` rollout), IB framework promotion + Stage 1 connector skeleton, IB Stage 2 (transport orders + contract resolver). Pure submodule fast-forward.
3. **`fix(gateway)`** — address sourcery-ai review feedback from #33 thread. `gateway_swap_command.py`: guard the BUY/SELL membership check with `side is not None` so the interactive-prompt path is not short-circuited by validation when side is omitted (sourcery: bug_risk). The companion `gateway_pool_command.py` normalization fix from the original commit was dropped during cherry-pick — the targeted `get_default_network_for_chain()` call no longer exists on current `ci-base` (the interactive update path was refactored to derive `chain` from `get_dex_info(connector)`).
4. **`test(cross-exchange-mm)`** — drain event loop before cancel-count assertion in `test_market_became_wider` and `test_market_became_narrower_top_depth_tolerance` to fix an intermittent race where the strategy's second cancel event had not yet been dispatched into `maker_cancel_order_logger.event_log` by the time the assertion executed. Adds `self.ev_loop.run_until_complete(asyncio.sleep(0.1))` immediately before the `assertEqual`. No assertion target or timing semantics change.

## Verification

Commits applied cleanly via cherry-pick (one semantic resolution noted above for `gateway_pool_command.py`). All 4 final commits GPG-signed (Verified). The lockfile regen and submodule bump are minimal-blast-radius chores; the gateway and test fixes are bug-risk and flake-fix patches respectively.

## Supersedes

Replaces #33. The 5th commit in #33 (`chore(submodule): bump remote-iface to 6477278a`) is obsolete — #35 took the pointer past Phase 4b to `7e725d5e`. PR #33 will be closed (not merged) with a pointer to this PR.

## Test plan

- [ ] CI green on ci-base targeting checks
- [ ] `pixi run install-subpackages` succeeds with new market-connector pointer
- [ ] Cross-exchange MM tests no longer flake on `test_market_became_wider` / `test_market_became_narrower_top_depth_tolerance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Regenerate dependency lockfile, update the market-connector submodule, fix gateway swap side validation, and stabilize flaky cross-exchange market making tests.

Bug Fixes:
- Guard gateway swap side validation to allow interactive prompts while rejecting invalid sides.
- Address a timing race in cross-exchange market making cancel-count assertions that caused intermittent test failures.

Tests:
- Add an explicit event loop delay before cancel-count assertions in cross-exchange market making tests to avoid flaky race conditions.

Chores:
- Regenerate the pixi lockfile without changing package versions.
- Fast-forward the market-connector submodule to the latest development pointer.