### PR TITLE
feat(submodule): add hb-web-assistant as sub-packages/web-assistant (PR 3a)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,7 @@
 	path = sub-packages/remote-iface
 	url = https://github.com/MementoRC/hb-remote-iface.git
 	branch = development
+[submodule "sub-packages/web-assistant"]
+	path = sub-packages/web-assistant
+	url = https://github.com/MementoRC/hb-web-assistant.git
+	branch = development


### PR DESCRIPTION
## PR 3a of the hb-web-assistant extraction sequence

Wires the freshly extracted [`hb-web-assistant`](https://github.com/MementoRC/hb-web-assistant) repository into the hummingbot tree as the 9th sub-package submodule.

### Submodule pin
- Path: `sub-packages/web-assistant`
- URL: `https://github.com/MementoRC/hb-web-assistant.git`
- Branch tracking: `development`
- Initial commit pin: `db45fc1f` (post-merge of MementoRC/hb-web-assistant#6)

### Upstream extraction summary
- Bundles `hummingbot.core.web_assistant` + `hummingbot.core.api_throttler` into a standalone Python 3.12+ package
- Bundle-with-internal-split pattern: api_throttler appears as `web_assistant.throttler` namespace
- Fully decoupled: zero `from hummingbot.*` imports in source
- 68 tests ported with minimal hummingbot dependencies replaced by local helpers (`tests/_helpers/network_mocking.py`, `tests/_helpers/isolated_asyncio_wrapper_test_case.py`)
- All quality gates green: ruff lint+format, mypy strict (20 src files), CodeQL Advanced Security, Semgrep SAST, Scorecard

### What this PR does NOT do
- Does NOT add re-export shims at `hummingbot/core/web_assistant/` or `hummingbot/core/api_throttler/` — those are deferred to PR 3b on `_for_bleed/web-assistant-extraction` (off `ci-base` after this merges).
- Does NOT migrate any of the 368 internal hummingbot consumers off the legacy paths — those happen in subsequent `_for_bleed/web-assistant-migration-<batch>` PRs after the shim layer lands.

### Next milestones (after this merges)
1. **PR 3b** on `_for_bleed/web-assistant-extraction` (branched off updated ci-base): wildcard re-export shims + `DeprecationWarning` + `test_shim_equivalence.py` smoke test.
2. Trigger ci-base → bleeding-edge rebuild via `custom_git_setup/scripts/hummingbot-branch-tracking.sh --rebuild` so the new submodule and the future shim are picked up across the tracked branch tier.
3. Follow-up `_for_bleed/web-assistant-migration-<batch>` PRs rewriting consumers per directory; final PR removes the shim.

### Test plan
- [ ] Submodule init succeeds (`git submodule update --init` after checkout)
- [ ] CI gates pass on ci-base CI workflows (no changes outside `.gitmodules` + submodule pointer)
- [ ] Submodule pin `db45fc1f` resolves on `MementoRC/hb-web-assistant`'s `development` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Introduce web-assistant as a standalone sub-package integrated via git submodule at sub-packages/web-assistant.