### PR TITLE
chore(.gitmodules): pin strategy-framework to development

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "sub-packages/strategy-framework"]
 	path = sub-packages/strategy-framework
 	url = https://github.com/MementoRC/hb-strategy-framework.git
-	branch = feat/hb-compat
+	branch = development
 [submodule "sub-packages/rate-oracle"]
 	path = sub-packages/rate-oracle
 	url = https://github.com/MementoRC/hb-rate-oracle.git


### PR DESCRIPTION
feat/hb-compat is fully merged into development on hb-strategy-framework (10 commits behind, 0 ahead). Aligns strategy-framework with the other 13 submodules which all pin branch = development.

Part of Task #5 (2nd submodule pointer bump, 2026-06-03). The gitlink update for strategy-framework rides separately on
_for_bleed/bump-subpackage-pointers-2026-06-03.

**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] Tests all pass
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:



**Tests performed by the developer**:



**Tips for QA testing**:

## Summary by Sourcery

Chores:
- Align the strategy-framework submodule branch pin with the other submodules by targeting the development branch in .gitmodules.