### PR TITLE
feat(ci): populate tach modules (Phase 1 coarse 15)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ ruff = "==0.15.7"
 mypy = "*"
 pre-commit = ">=3.3.3"
 cython-lint = "*"
+tach = ">=0.20"
 
 [tool.pixi.feature.ci.dependencies]
 bandit = "*"
@@ -156,6 +157,9 @@ compat-integration = { cmd = "pytest sub-packages/candles-feed/tests/unit/test_c
 compat-check = { depends-on = ["compat-import", "compat-contract", "compat-integration"] }
 migrate-pytest = { cmd = "python $HOME/PycharmProjects/refactor-applications/refactor/rules/pytest_migration.py -d --apply --verbose test/", env = { PYTHONPATH = "$HOME/PycharmProjects/refactor-applications:$PYTHONPATH" } }
 migrate-pytest-dry = { cmd = "python $HOME/PycharmProjects/refactor-applications/refactor/rules/pytest_migration.py -d --verbose test/", env = { PYTHONPATH = "$HOME/PycharmProjects/refactor-applications:$PYTHONPATH" } }
+lint-boundaries = { cmd = "tach check", description = "Enforce import boundaries between modules and sub-packages" }
+dep-graph = { cmd = "python ../custom_git_setup/scripts/dep_graph.py", description = "Emit sub-package dependency graph as JSON" }
+test-all-subpackages = { cmd = "bash ../custom_git_setup/scripts/test_all_subpackages.sh", description = "Run tests across all 14 sub-packages" }
 
 [tool.isort]
 line_length = 120

--- a/tach.toml
+++ b/tach.toml
@@ -1,0 +1,44 @@
+# tach configuration — module boundary enforcement
+# See https://docs.gauge.sh/tach for full documentation
+#
+# C2b-minimal: infrastructure stub only.
+# modules=[] means tach check is a trivial no-op (passes "all modules validated"
+# with WARN "no first-party imports found"). Real enforcement requires
+# resolving the layout/tooling mismatch: hummingbot's sub-packages live at
+# sub-packages/<hyphen-dir>/<underscore-pkg>/__init__.py (git submodules) and
+# tach 0.35 prunes them under every tested source_roots configuration.
+#
+# Future work needs to choose:
+#   - import-linter (regex-based contracts, may fit this layout better)
+#   - Restructure sub-packages to src/ layout
+#   - Different tach version or config we haven't found yet
+#
+# Plan: hummingbot_ai_docs/2026-06-04-tach-mod-integration-plan.md
+# Investigation memory: project_tach_mod_audit_2026_06_04.md
+
+source_roots = [
+  ".",
+]
+
+exclude = [
+  "**/tests/**",
+  "**/__pycache__/**",
+  "**/.pixi/**",
+  "**/build/**",
+  "**/.git/**",
+  # Cython artifacts — .so not parseable Python, .pyx uses cdef/cimport
+  "**/*.so",
+  "**/*.pyd",
+  "**/*.pyx",
+  "**/*.pxd",
+  # Rust crate — no Python modules; _hb_rust .so lands in site-packages
+  "**/rust/**",
+  # Build/dist artifacts
+  "**/target/**",
+  "**/dist/**",
+  "**/*.egg-info/**",
+  # Worktree artifacts (submodule .worktrees pattern per sub-package skill)
+  "**/.worktrees/**",
+]
+
+modules = []


### PR DESCRIPTION
## Summary

**C2b-minimal rewrite** — ships tach infrastructure self-contained for ci-base persistence. Force-pushed after discovering the cron's destructive rebuild of ci-base wipes `_for_ci/modularization-tooling` content and that tach 0.35 cannot enforce boundaries on hummingbot's sub-package layout under any tested config.

## What ships

Single atomic commit (`2da267fe`) adds:
- `tach.toml` stub: `modules = []` + comprehensive exclude (`.pyx`/`.pxd`/`.so`/`.pyd`, Rust `rust/`+`target/`, build/dist artifacts, submodule `.worktrees/`, tests, `__pycache__`)
- `tach >=0.20` dev dependency
- `lint-boundaries` pixi task (`tach check`)
- `dep-graph` pixi task (sub-package dependency graph JSON)
- `test-all-subpackages` pixi task (run tests across 14 sub-packages)

## What this does NOT do

`modules = []` makes `tach check` a **trivial no-op**:
```
[WARN] No first-party imports were found.
✅ All modules validated!
```

Real boundary enforcement is **future work**. Two configurations tried this session, both produced no-op:
1. `source_roots=['.', 14 sub_pkg dirs]` — tach pruned 14 sub-packages, kept only hummingbot
2. `source_roots=[14 sub_pkg dirs only]` — tach pruned all 14 modules

## Why this is still worth shipping

The cron's ci-base rebuild is **destructive** — re-syncing with upstream/development drops `_for_ci/modularization-tooling` content silently. Without this PR, every cron cycle deletes `tach.toml`, the tach dep, and the pixi tasks. Shipping the infrastructure self-contained means it persists in `_for_ci/tach-modules-coarse` (tracked in `branch-tracking.yaml`) and gets re-merged each cron cycle.

## What needs investigation before this becomes useful

Unknown: how to make tach (or any boundary tool) enforce import boundaries on hummingbot's layout where:
- Top-level `hummingbot/` is a Python package
- Sub-packages live at `sub-packages/<hyphen-dir>/<underscore-pkg>/__init__.py` (git submodules)
- The two layers can't share a single `source_roots` config that tach respects

Candidates for future work:
- **import-linter** (regex-based contracts; different model from tach's graph)
- Restructure sub-packages to `src/` layout (large refactor)
- A tach config we haven't found yet

## Verification

- `pixi run lint-boundaries` exit 0 (trivially passes with WARN)
- `pixi run lint` clean on ci-base alone
- Branch is fast-forward from origin/ci-base tip `101230c8`

## Plan + investigation memory

- Plan: `hummingbot_ai_docs/2026-06-04-tach-mod-integration-plan.md`
- Session findings: memory `project_tach_mod_audit_2026_06_04.md` + learning `learn_b8ad0d8cf083`

## Test plan

- [ ] CI green on this branch (lint/typecheck/security/sub-package compat)
- [ ] Next cron rebuild cycle picks it up via `branch-tracking.yaml`
- [ ] Follow-up issue/PR: choose boundary-enforcement tool (import-linter vs other)