### PR TITLE
fix(ci): remove undefined compat-contract and compat-integration tasks

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -170,12 +170,6 @@ jobs:
       - name: Import smoke test
         run: pixi run -e ci compat-import
 
-      - name: Interface contract check
-        run: pixi run -e ci compat-contract
-
-      - name: Integration compatibility tests
-        run: pixi run -e ci compat-integration
-
   ci-success:
     name: CI Success
     if: always()


### PR DESCRIPTION
## Summary
- Removes 2 step blocks from `.github/workflows/workflow.yml` that called `pixi run -e ci compat-contract` and `pixi run -e ci compat-integration`.
- Neither task was defined in `pyproject.toml`, causing exit 127 on every CI run.
- `compat-import` step is preserved (it's defined and works).

## Why
The plan that introduced these task names was lost. Removing the steps unblocks ci-base PR #22 (ci-base → development).
Future restoration of these checks requires defining the tasks in `pyproject.toml` first.

## Test plan
- [ ] Quality gates pass on this PR
- [ ] sub-packages-compat job completes (only `compat-import` step runs)
- [ ] Once merged: ci-base PR #22 sub-packages-compat job no longer hits exit 127

## Summary by Sourcery

CI:
- Delete CI steps invoking undefined compat-contract and compat-integration pixi tasks from the sub-packages-compat job.