### PR TITLE
fix(test-selection): add conftest.py + pyproject.toml to cross_cutting

### DIFF
--- a/.github/test-selection/test-selection-map.yaml
+++ b/.github/test-selection/test-selection-map.yaml
@@ -65,6 +65,7 @@ extra_mappings:
 
 # Cross-cutting: any change to source_glob triggers tests_globs (broad)
 # Seed minimal — grow from shadow-mode misses.
+# Top-level config files (conftest.py, pyproject.toml) added 2026-06-12 — they affect every test.
 cross_cutting:
   - source_glob: "hummingbot/core/pubsub.*"
     tests_globs: ["test/hummingbot/**/*.py"]
@@ -74,6 +75,10 @@ cross_cutting:
     tests_globs: ["test/hummingbot/strategy_v2/**/*.py"]
   - source_glob: "hummingbot/core/data_type/common.py"
     tests_globs: ["test/hummingbot/**/*.py"]
+  - source_glob: "conftest.py"
+    tests_globs: ["test/**/*.py"]
+  - source_glob: "pyproject.toml"
+    tests_globs: ["test/**/*.py"]
 
 # Selected/total > N% triggers exit code 2 (caller falls back to full suite)
 escape_threshold_pct: 50


### PR DESCRIPTION
## Why

Preempts a silent-skip regression in the next PR (smart-select extension to workflow.yml).

The diff-driven test selector at `.github/test-selection/select_tests.py` uses three rule tiers:
1. **mirror rule** — `hummingbot/X/foo.py` → `test/hummingbot/X/test_foo.py`
2. **extra_mappings** — hand-curated path mappings
3. **cross_cutting** — if changed, broad tests glob is selected

Problem: `conftest.py` and `pyproject.toml` were in **NEITHER** the ignore list NOR cross_cutting. The mirror rule would map them to non-existent `test_conftest.py` / `test_pyproject.py` → zero tests selected.

For today's quick-check.yml (the only existing selector consumer), this is currently masked because PRs touching only these files are rare. But the planned smart-select extension to `workflow.yml`'s Build+Test job introduces a `skip pytest if selection empty` code path that would silently miss config-only PRs.

## What changed

| File | Diff |
|---|---|
| `.github/test-selection/test-selection-map.yaml` | +5 lines: 2 new `cross_cutting` entries (`conftest.py`, `pyproject.toml`) + 1 comment line |

New entries use the wider `test/**/*.py` glob (vs the `test/hummingbot/**/*.py` used by existing scoped entries) because top-level config truly affects every test directory: `test/mock`, `test/connector`, etc., not just `test/hummingbot`.

## Risk

Low. Only affects selector behavior; no production code touched. Worst case: a future PR touching only `conftest.py` triggers full-suite where it might not have needed to — that's the safe default.

## Verification

Commit `3c98fd5e` GPG-signed with key `C7927B4C27159961` (VERIFIED).

## Followup

After this merges, the smart-select PR (workflow.yml + quick-check.yml triggers) can land safely.

## Summary by Sourcery

Enhancements:
- Add conftest.py and pyproject.toml as cross-cutting sources that trigger running the full Python test suite when modified.