### PR TITLE
fix(test): stabilize foxbit test_client_order_id_on_order

### DIFF
--- a/test/hummingbot/connector/exchange/foxbit/test_foxbit_exchange.py
+++ b/test/hummingbot/connector/exchange/foxbit/test_foxbit_exchange.py
@@ -859,31 +859,41 @@ class FoxbitExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests)
     def test_client_order_id_on_order(self):
         self.exchange._set_current_timestamp(1640780000)
 
-        result = self.exchange.buy(
-            trading_pair=self.trading_pair,
-            amount=Decimal("1"),
-            order_type=OrderType.LIMIT,
-            price=Decimal("2"),
-        )
-        expected_client_order_id = utils.get_client_order_id(
-            is_buy=True,
-        )
+        # Patch get_tracking_nonce at the foxbit_utils import site so every call
+        # within this test returns a fixed value. Without this, successive calls
+        # to the microsecond-precision monotone-incrementing nonce provider return
+        # different values, causing the production call inside buy()/sell() and the
+        # verification call to get_client_order_id() to disagree on the [:10] slice.
+        fixed_nonce = 1640780000123456
+        with patch(
+            "hummingbot.connector.exchange.foxbit.foxbit_utils.get_tracking_nonce",
+            return_value=fixed_nonce,
+        ):
+            result = self.exchange.buy(
+                trading_pair=self.trading_pair,
+                amount=Decimal("1"),
+                order_type=OrderType.LIMIT,
+                price=Decimal("2"),
+            )
+            expected_client_order_id = utils.get_client_order_id(
+                is_buy=True,
+            )
 
-        self.assertEqual(result[:10], expected_client_order_id[:10])
-        self.assertEqual(result[3], "0")
-        self.assertLess(len(expected_client_order_id), self.exchange.client_order_id_max_length)
+            self.assertEqual(result[:10], expected_client_order_id[:10])
+            self.assertEqual(result[3], "0")
+            self.assertLess(len(expected_client_order_id), self.exchange.client_order_id_max_length)
 
-        result = self.exchange.sell(
-            trading_pair=self.trading_pair,
-            amount=Decimal("1"),
-            order_type=OrderType.LIMIT,
-            price=Decimal("2"),
-        )
-        expected_client_order_id = utils.get_client_order_id(
-            is_buy=False,
-        )
+            result = self.exchange.sell(
+                trading_pair=self.trading_pair,
+                amount=Decimal("1"),
+                order_type=OrderType.LIMIT,
+                price=Decimal("2"),
+            )
+            expected_client_order_id = utils.get_client_order_id(
+                is_buy=False,
+            )
 
-        self.assertEqual(result[:10], expected_client_order_id[:10])
+            self.assertEqual(result[:10], expected_client_order_id[:10])
 
     @aioresponses()
     async def test_create_order(self, mock_api):


### PR DESCRIPTION
Re-opened from PR #57 (incorrectly based on bleeding-edge).

Test was flaky due to timestamp-based race between get_tracking_nonce() calls inside production buy/sell and verification utils.get_client_order_id(). Microsecond-precision monotone-incrementing nonce provider guarantees successive calls return different values.

Fix: patch foxbit_utils.get_tracking_nonce with a fixed return value for test duration. No production code changes.

Surfaced on PR #56 push-event quick-check. Narrow fix to ci-base only.

Diff: 1 file / +28 / -0

## Summary by Sourcery

Stabilize the foxbit client order ID test by removing its dependency on time-based nonces.

Bug Fixes:
- Fix flaky foxbit client order ID test caused by timestamp-based nonce differences between production and verification calls.

Tests:
- Update foxbit client order ID test to patch the tracking nonce provider with a fixed value during the test.