### PR TITLE
chore(ci): replace isort with ruff I-rule + fix order on connectors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,9 +27,3 @@ repos:
       - id: detect-wallet-private-key
         types: [file]
         exclude: .json
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        files: "\\.(py)$"
-        args: [--settings-path=pyproject.toml]

--- a/hummingbot/client/command/mqtt_command.py
+++ b/hummingbot/client/command/mqtt_command.py
@@ -3,9 +3,10 @@ import threading
 import time
 from typing import TYPE_CHECKING
 
-from hummingbot.core.utils.async_utils import safe_ensure_future
 from remote_iface.hb_compat import create_gateway
 from remote_iface.protocols.config import BrokerConfig, GatewayConfig
+
+from hummingbot.core.utils.async_utils import safe_ensure_future
 
 if TYPE_CHECKING:
     from hummingbot.client.hummingbot_application import HummingbotApplication  # noqa: F401

--- a/hummingbot/client/hummingbot_application.py
+++ b/hummingbot/client/hummingbot_application.py
@@ -6,6 +6,7 @@ import time
 from collections import deque
 from typing import Deque, Union
 
+from remote_iface import MQTTGateway
 from sqlalchemy.orm import Session
 
 from hummingbot.client.command import __all__ as commands
@@ -33,7 +34,6 @@ from hummingbot.exceptions import ArgumentParserError
 from hummingbot.logger import HummingbotLogger
 from hummingbot.logger.application_warning import ApplicationWarning
 from hummingbot.model.trade_fill import TradeFill
-from remote_iface import MQTTGateway
 
 s_logger = None
 

--- a/hummingbot/connector/derivative/dydx_v4_perpetual/dydx_v4_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/dydx_v4_perpetual/dydx_v4_perpetual_api_order_book_data_source.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Union
 
 import dateutil.parser as dp
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.derivative.dydx_v4_perpetual import (
     dydx_v4_perpetual_constants as CONSTANTS,
@@ -20,7 +21,6 @@ from hummingbot.core.data_type.perpetual_api_order_book_data_source import Perpe
 from hummingbot.core.utils.tracking_nonce import NonceCreator
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.derivative.dydx_v4_perpetual.dydx_v4_perpetual_derivative import DydxV4PerpetualDerivative

--- a/hummingbot/connector/derivative/dydx_v4_perpetual/dydx_v4_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/dydx_v4_perpetual/dydx_v4_perpetual_derivative.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import Any, Dict, List
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 import hummingbot.connector.derivative.dydx_v4_perpetual.dydx_v4_perpetual_constants as CONSTANTS
 from hummingbot.connector.constants import s_decimal_0, s_decimal_NaN
@@ -31,7 +32,6 @@ from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.estimate_fee import build_perpetual_trade_fee
 from hummingbot.core.utils.tracking_nonce import NonceCreator
 from hummingbot.core.web_assistant.auth import AuthBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class DydxV4PerpetualDerivative(PerpetualDerivativePyBase):

--- a/hummingbot/connector/derivative/dydx_v4_perpetual/dydx_v4_perpetual_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/dydx_v4_perpetual/dydx_v4_perpetual_user_stream_data_source.py
@@ -4,12 +4,13 @@ import asyncio
 import logging
 from typing import Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.derivative.dydx_v4_perpetual.dydx_v4_perpetual_constants as CONSTANTS
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class DydxV4PerpetualUserStreamDataSource(UserStreamTrackerDataSource):

--- a/hummingbot/connector/derivative/dydx_v4_perpetual/dydx_v4_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/dydx_v4_perpetual/dydx_v4_perpetual_web_utils.py
@@ -1,10 +1,11 @@
 from typing import Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.derivative.dydx_v4_perpetual.dydx_v4_perpetual_constants as CONSTANTS
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest
 from hummingbot.core.web_assistant.rest_pre_processors import RESTPreProcessorBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class DydxV4PerpetualRESTPreProcessor(RESTPreProcessorBase):

--- a/hummingbot/connector/derivative/evedex_perpetual/evedex_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/evedex_perpetual/evedex_perpetual_api_order_book_data_source.py
@@ -6,6 +6,8 @@ from collections import defaultdict
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.derivative.evedex_perpetual.evedex_perpetual_constants as CONSTANTS
 import hummingbot.connector.derivative.evedex_perpetual.evedex_perpetual_web_utils as web_utils
 from hummingbot.core.data_type.common import TradeType
@@ -15,7 +17,6 @@ from hummingbot.core.data_type.perpetual_api_order_book_data_source import Perpe
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.derivative.evedex_perpetual.evedex_perpetual_derivative import EvedexPerpetualDerivative

--- a/hummingbot/connector/derivative/evedex_perpetual/evedex_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/evedex_perpetual/evedex_perpetual_derivative.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from typing import Any, AsyncIterable
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.derivative.evedex_perpetual import (
@@ -34,7 +35,6 @@ from hummingbot.core.data_type.trade_fee import TokenAmount, TradeFeeBase
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
 from hummingbot.core.utils.estimate_fee import build_trade_fee
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 epm_logger = None
 

--- a/hummingbot/connector/derivative/evedex_perpetual/evedex_perpetual_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/evedex_perpetual/evedex_perpetual_user_stream_data_source.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.derivative.evedex_perpetual.evedex_perpetual_constants as CONSTANTS
 import hummingbot.connector.derivative.evedex_perpetual.evedex_perpetual_web_utils as web_utils
 from hummingbot.connector.derivative.evedex_perpetual.evedex_perpetual_auth import EvedexPerpetualAuth
@@ -10,7 +12,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.derivative.evedex_perpetual.evedex_perpetual_derivative import EvedexPerpetualDerivative

--- a/hummingbot/connector/derivative/evedex_perpetual/evedex_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/evedex_perpetual/evedex_perpetual_web_utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.derivative.evedex_perpetual.evedex_perpetual_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
@@ -9,7 +11,6 @@ from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest
 from hummingbot.core.web_assistant.rest_pre_processors import RESTPreProcessorBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class EvedexPerpetualRESTPreProcessor(RESTPreProcessorBase):

--- a/hummingbot/connector/derivative/gate_io_perpetual/gate_io_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/gate_io_perpetual/gate_io_perpetual_api_order_book_data_source.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 import pandas as pd
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.derivative.gate_io_perpetual import (
     gate_io_perpetual_constants as CONSTANTS,
@@ -19,7 +20,6 @@ from hummingbot.core.data_type.order_book_message import OrderBookMessageType
 from hummingbot.core.data_type.perpetual_api_order_book_data_source import PerpetualAPIOrderBookDataSource
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.derivative.gate_io_perpetual.gate_io_perpetual_derivative import GateIoPerpetualDerivative

--- a/hummingbot/connector/derivative/gate_io_perpetual/gate_io_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/gate_io_perpetual/gate_io_perpetual_derivative.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import Any
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.derivative.gate_io_perpetual import (
@@ -31,7 +32,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class GateIoPerpetualDerivative(PerpetualDerivativePyBase):

--- a/hummingbot/connector/derivative/injective_v2_perpetual/injective_v2_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/injective_v2_perpetual/injective_v2_perpetual_derivative.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Any, Callable, Union
 
 from async_timeout import timeout
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.client_order_tracker import ClientOrderTracker
 from hummingbot.connector.constants import FUNDING_FEE_POLL_INTERVAL, s_decimal_NaN
@@ -40,7 +41,6 @@ from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.estimate_fee import build_perpetual_trade_fee
 from hummingbot.core.web_assistant.auth import AuthBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class InjectiveV2PerpetualDerivative(PerpetualDerivativePyBase):

--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_api_order_book_data_source.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Union
 
 import pandas as pd
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.derivative.kucoin_perpetual import (
     kucoin_perpetual_constants as CONSTANTS,
@@ -18,7 +19,6 @@ from hummingbot.core.data_type.perpetual_api_order_book_data_source import Perpe
 from hummingbot.core.utils.tracking_nonce import NonceCreator
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.derivative.kucoin_perpetual.kucoin_perpetual_derivative import KucoinPerpetualDerivative

--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_api_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_api_user_stream_data_source.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.derivative.kucoin_perpetual import (
     kucoin_perpetual_constants as CONSTANTS,
     kucoin_perpetual_web_utils as web_utils,
@@ -12,7 +14,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.derivative.kucoin_perpetual.kucoin_perpetual_derivative import KucoinPerpetualDerivative

--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_derivative.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Union
 
 import pandas as pd
 from bidict import ValueDuplicationError, bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 import hummingbot.connector.derivative.kucoin_perpetual.kucoin_perpetual_constants as CONSTANTS
 import hummingbot.connector.derivative.kucoin_perpetual.kucoin_perpetual_utils as kucoin_utils
@@ -31,7 +32,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.utils.async_utils import safe_gather
 from hummingbot.core.utils.estimate_fee import build_perpetual_trade_fee
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 s_decimal_NaN = Decimal("nan")
 s_decimal_0 = Decimal(0)

--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_web_utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.derivative.kucoin_perpetual import kucoin_perpetual_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
@@ -10,7 +12,6 @@ from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest
 from hummingbot.core.web_assistant.rest_pre_processors import RESTPreProcessorBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class HeadersContentRESTPreProcessor(RESTPreProcessorBase):

--- a/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_api_order_book_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.derivative.okx_perpetual import (
     okx_perpetual_constants as CONSTANTS,
     okx_perpetual_web_utils as web_utils,
@@ -16,7 +18,6 @@ from hummingbot.core.data_type.perpetual_api_order_book_data_source import Perpe
 from hummingbot.core.utils.tracking_nonce import NonceCreator
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.derivative.okx_perpetual.okx_perpetual_derivative import OkxPerpetualDerivative

--- a/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_derivative.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import Any, Dict, Union
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 import hummingbot.connector.derivative.okx_perpetual.okx_perpetual_constants as CONSTANTS
 import hummingbot.connector.derivative.okx_perpetual.okx_perpetual_utils as okx_utils
@@ -29,7 +30,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.utils.async_utils import safe_gather
 from hummingbot.core.utils.estimate_fee import build_perpetual_trade_fee
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 s_decimal_NaN = Decimal("nan")
 s_decimal_0 = Decimal(0)

--- a/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_user_stream_data_source.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.derivative.okx_perpetual import (
     okx_perpetual_constants as CONSTANTS,
     okx_perpetual_web_utils as web_utils,
@@ -11,7 +13,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSResponse
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class OkxPerpetualUserStreamDataSource(UserStreamTrackerDataSource):

--- a/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_web_utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.derivative.okx_perpetual import okx_perpetual_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
@@ -10,7 +12,6 @@ from hummingbot.core.api_throttler.data_types import RateLimit
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest
 from hummingbot.core.web_assistant.rest_pre_processors import RESTPreProcessorBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class HeadersContentRESTPreProcessor(RESTPreProcessorBase):

--- a/hummingbot/connector/derivative/pacifica_perpetual/pacifica_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/pacifica_perpetual/pacifica_perpetual_api_order_book_data_source.py
@@ -5,6 +5,8 @@ import time
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.derivative.pacifica_perpetual import (
     pacifica_perpetual_constants as CONSTANTS,
     pacifica_perpetual_web_utils as web_utils,
@@ -17,7 +19,6 @@ from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.derivative.pacifica_perpetual.pacifica_perpetual_derivative import (

--- a/hummingbot/connector/derivative/pacifica_perpetual/pacifica_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/pacifica_perpetual/pacifica_perpetual_derivative.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import Any, NamedTuple
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 import hummingbot.connector.derivative.pacifica_perpetual.pacifica_perpetual_constants as CONSTANTS
 import hummingbot.connector.derivative.pacifica_perpetual.pacifica_perpetual_web_utils as web_utils
@@ -29,7 +30,6 @@ from hummingbot.core.data_type.trade_fee import TokenAmount, TradeFeeBase, Trade
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 s_decimal_0 = Decimal(0)
 

--- a/hummingbot/connector/derivative/pacifica_perpetual/pacifica_perpetual_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/pacifica_perpetual/pacifica_perpetual_user_stream_data_source.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.derivative.pacifica_perpetual import (
     pacifica_perpetual_constants as CONSTANTS,
     pacifica_perpetual_web_utils as web_utils,
@@ -13,7 +15,6 @@ from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.derivative.pacifica_perpetual.pacifica_perpetual_derivative import (

--- a/hummingbot/connector/derivative/pacifica_perpetual/pacifica_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/pacifica_perpetual/pacifica_perpetual_web_utils.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import time
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.derivative.pacifica_perpetual import pacifica_perpetual_constants as CONSTANTS
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_api_order_book_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.ascend_ex import ascend_ex_constants as CONSTANTS, ascend_ex_web_utils as web_utils
 from hummingbot.core.data_type.common import TradeType
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
@@ -11,7 +13,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.ascend_ex.ascend_ex_exchange import AscendExExchange

--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_api_user_stream_data_source.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.ascend_ex import ascend_ex_constants as CONSTANTS
 from hummingbot.connector.exchange.ascend_ex.ascend_ex_auth import AscendExAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.ascend_ex.ascend_ex_exchange import AscendExExchange

--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import Any
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.exchange.ascend_ex import (
@@ -27,7 +28,6 @@ from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class AscendExExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_web_utils.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_web_utils.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import time
 from typing import Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.ascend_ex import ascend_ex_constants as CONSTANTS
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTRequest
 from hummingbot.core.web_assistant.rest_pre_processors import RESTPreProcessorBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class AscendExRESTPreProcessor(RESTPreProcessorBase):

--- a/hummingbot/connector/exchange/backpack/backpack_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/backpack/backpack_api_order_book_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import time
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.backpack import backpack_constants as CONSTANTS, backpack_web_utils as web_utils
 from hummingbot.connector.exchange.backpack.backpack_order_book import BackpackOrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
@@ -11,7 +13,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.backpack.backpack_exchange import BackpackExchange

--- a/hummingbot/connector/exchange/backpack/backpack_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/backpack/backpack_api_user_stream_data_source.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.backpack import backpack_constants as CONSTANTS
 from hummingbot.connector.exchange.backpack.backpack_auth import BackpackAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
@@ -10,7 +12,6 @@ from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.backpack.backpack_exchange import BackpackExchange

--- a/hummingbot/connector/exchange/backpack/backpack_exchange.py
+++ b/hummingbot/connector/exchange/backpack/backpack_exchange.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pandas as pd
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.exchange.backpack import (
@@ -27,7 +28,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.tracking_nonce import NonceCreator
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class BackpackExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/backpack/backpack_web_utils.py
+++ b/hummingbot/connector/exchange/backpack/backpack_web_utils.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from typing import Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.backpack.backpack_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/binance/binance_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/binance/binance_api_order_book_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import time
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.binance import binance_constants as CONSTANTS, binance_web_utils as web_utils
 from hummingbot.connector.exchange.binance.binance_order_book import BinanceOrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
@@ -11,7 +13,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.binance.binance_exchange import BinanceExchange

--- a/hummingbot/connector/exchange/binance/binance_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/binance/binance_api_user_stream_data_source.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.binance import binance_constants as CONSTANTS
 from hummingbot.connector.exchange.binance.binance_auth import BinanceAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSResponse
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.binance.binance_exchange import BinanceExchange

--- a/hummingbot/connector/exchange/binance/binance_exchange.py
+++ b/hummingbot/connector/exchange/binance/binance_exchange.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import Any
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.exchange.binance import (
@@ -26,7 +27,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.event.events import MarketEvent, OrderFilledEvent
 from hummingbot.core.utils.async_utils import safe_gather
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class BinanceExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/binance/binance_web_utils.py
+++ b/hummingbot/connector/exchange/binance/binance_web_utils.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from typing import Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.binance.binance_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/bing_x/bing_x_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/bing_x/bing_x_api_order_book_data_source.py
@@ -5,6 +5,8 @@ import time
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Mapping
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.bing_x.bing_x_constants as CONSTANTS
 import hummingbot.connector.exchange.bing_x.bing_x_utils as utils
 from hummingbot.connector.exchange.bing_x import bing_x_web_utils as web_utils
@@ -16,7 +18,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.bing_x.bing_x_exchange import BingXExchange

--- a/hummingbot/connector/exchange/bing_x/bing_x_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/bing_x/bing_x_api_user_stream_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import logging
 import time
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.bing_x.bing_x_constants as CONSTANTS
 import hummingbot.connector.exchange.bing_x.bing_x_utils as utils
 import hummingbot.connector.exchange.bing_x.bing_x_web_utils as web_utils
@@ -14,7 +16,6 @@ from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class BingXAPIUserStreamDataSource(UserStreamTrackerDataSource):

--- a/hummingbot/connector/exchange/bing_x/bing_x_exchange.py
+++ b/hummingbot/connector/exchange/bing_x/bing_x_exchange.py
@@ -7,6 +7,7 @@ from types import MethodType
 from typing import Any, Union
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 import hummingbot.connector.exchange.bing_x.bing_x_constants as CONSTANTS
 import hummingbot.connector.exchange.bing_x.bing_x_utils as bing_x_utils
@@ -23,7 +24,6 @@ from hummingbot.core.data_type.trade_fee import TokenAmount, TradeFeeBase
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 s_logger = None
 s_decimal_NaN = Decimal("nan")

--- a/hummingbot/connector/exchange/bing_x/bing_x_web_utils.py
+++ b/hummingbot/connector/exchange/bing_x/bing_x_web_utils.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from typing import Any, Callable
 from urllib.parse import urljoin
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.bing_x.bing_x_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/bitget/bitget_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/bitget/bitget_api_order_book_data_source.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, NoReturn
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.bitget import bitget_constants as CONSTANTS, bitget_web_utils as web_utils
 from hummingbot.core.data_type.common import TradeType
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
@@ -10,7 +12,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest, WSPlainTextRequest
 from hummingbot.core.web_assistant.rest_assistant import RESTAssistant
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.bitget.bitget_exchange import BitgetExchange

--- a/hummingbot/connector/exchange/bitget/bitget_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/bitget/bitget_api_user_stream_data_source.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, NoReturn
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.bitget import bitget_constants as CONSTANTS, bitget_web_utils as web_utils
 from hummingbot.connector.exchange.bitget.bitget_auth import BitgetAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSPlainTextRequest, WSResponse
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.bitget.bitget_exchange import BitgetExchange

--- a/hummingbot/connector/exchange/bitget/bitget_exchange.py
+++ b/hummingbot/connector/exchange/bitget/bitget_exchange.py
@@ -5,6 +5,7 @@ from decimal import ROUND_UP, Decimal
 from typing import Any, Dict, Literal, Union
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 import hummingbot.connector.exchange.bitget.bitget_constants as CONSTANTS
 from hummingbot.connector.exchange.bitget import bitget_utils, bitget_web_utils as web_utils
@@ -21,7 +22,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.data_type.trade_fee import TokenAmount, TradeFeeBase, TradeFeeSchema
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.utils.estimate_fee import build_trade_fee
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 s_decimal_NaN = Decimal("nan")
 

--- a/hummingbot/connector/exchange/bitget/bitget_web_utils.py
+++ b/hummingbot/connector/exchange/bitget/bitget_web_utils.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from typing import Callable
 from urllib.parse import urljoin
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.bitget import bitget_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_ws_url(domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/bitmart/bitmart_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/bitmart/bitmart_api_order_book_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import json
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.bitmart import (
     bitmart_constants as CONSTANTS,
     bitmart_utils as utils,
@@ -15,7 +17,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.bitmart.bitmart_exchange import BitmartExchange

--- a/hummingbot/connector/exchange/bitmart/bitmart_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/bitmart/bitmart_api_user_stream_data_source.py
@@ -4,13 +4,14 @@ import asyncio
 import json
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.bitmart import bitmart_constants as CONSTANTS, bitmart_utils as utils
 from hummingbot.connector.exchange.bitmart.bitmart_auth import BitmartAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSResponse
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.bitmart.bitmart_exchange import BitmartExchange

--- a/hummingbot/connector/exchange/bitmart/bitmart_exchange.py
+++ b/hummingbot/connector/exchange/bitmart/bitmart_exchange.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import Any
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.exchange.bitmart import (
@@ -24,7 +25,6 @@ from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState,
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
 from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount, TradeFeeBase
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class BitmartExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/bitmart/bitmart_web_utils.py
+++ b/hummingbot/connector/exchange/bitmart/bitmart_web_utils.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from typing import Callable
 from urllib.parse import urljoin
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.bitmart.bitmart_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, **kwargs) -> str:

--- a/hummingbot/connector/exchange/bitrue/bitrue_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/bitrue/bitrue_api_order_book_data_source.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, Dict
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.bitrue import bitrue_constants as CONSTANTS, bitrue_web_utils as web_utils
 from hummingbot.connector.exchange.bitrue.bitrue_order_book import BitrueOrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
@@ -11,7 +13,6 @@ from hummingbot.core.utils.tracking_nonce import NonceCreator
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.bitrue.bitrue_exchange import BitrueExchange

--- a/hummingbot/connector/exchange/bitrue/bitrue_exchange.py
+++ b/hummingbot/connector/exchange/bitrue/bitrue_exchange.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from bidict import bidict
 from cachetools import TTLCache
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import DAY, MINUTE, SECOND, TWELVE_HOURS, s_decimal_NaN
 from hummingbot.connector.exchange.bitrue import (
@@ -28,7 +29,6 @@ from hummingbot.core.data_type.trade_fee import DeductedFromReturnsTradeFee, Tok
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class BitrueExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/bitrue/bitrue_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/bitrue/bitrue_user_stream_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import time
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.bitrue import bitrue_constants as CONSTANTS
 from hummingbot.connector.exchange.bitrue.bitrue_auth import BitrueAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
@@ -12,7 +14,6 @@ from hummingbot.core.utils.tracking_nonce import NonceCreator
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.bitrue.bitrue_exchange import BitrueExchange

--- a/hummingbot/connector/exchange/bitrue/bitrue_web_utils.py
+++ b/hummingbot/connector/exchange/bitrue/bitrue_web_utils.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from typing import Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.bitrue.bitrue_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import GZipCompressionWSPostProcessor, TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_api_order_book_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import time
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.bitstamp import bitstamp_constants as CONSTANTS, bitstamp_web_utils as web_utils
 from hummingbot.connector.exchange.bitstamp.bitstamp_order_book import BitstampOrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
@@ -11,7 +13,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.bitstamp.bitstamp_exchange import BitstampExchange

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_api_user_stream_data_source.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.bitstamp import bitstamp_constants as CONSTANTS, bitstamp_web_utils as web_utils
 from hummingbot.connector.exchange.bitstamp.bitstamp_auth import BitstampAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.bitstamp.bitstamp_exchange import BitstampExchange

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_exchange.py
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_exchange.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import Any, Callable
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.exchange.bitstamp import (
@@ -26,7 +27,6 @@ from hummingbot.core.data_type.trade_fee import TokenAmount, TradeFeeBase, Trade
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class BitstampExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/bitstamp/bitstamp_web_utils.py
+++ b/hummingbot/connector/exchange/bitstamp/bitstamp_web_utils.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from typing import Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.bitstamp.bitstamp_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
@@ -10,7 +12,6 @@ from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest
 from hummingbot.core.web_assistant.rest_pre_processors import RESTPreProcessorBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class BitstampRESTPreProcessor(RESTPreProcessorBase):

--- a/hummingbot/connector/exchange/btc_markets/btc_markets_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/btc_markets/btc_markets_api_order_book_data_source.py
@@ -4,6 +4,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any
 
 from dateutil.parser import parse as dateparse
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 import hummingbot.connector.exchange.btc_markets.btc_markets_constants as CONSTANTS
 from hummingbot.connector.exchange.btc_markets import btc_markets_web_utils as web_utils
@@ -13,7 +14,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.btc_markets.btc_markets_exchange import BtcMarketsExchange

--- a/hummingbot/connector/exchange/btc_markets/btc_markets_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/btc_markets/btc_markets_api_user_stream_data_source.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.btc_markets.btc_markets_constants as CONSTANTS
 from hummingbot.connector.exchange.btc_markets.btc_markets_auth import BtcMarketsAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.btc_markets.btc_markets_exchange import BtcMarketsExchange

--- a/hummingbot/connector/exchange/btc_markets/btc_markets_exchange.py
+++ b/hummingbot/connector/exchange/btc_markets/btc_markets_exchange.py
@@ -7,6 +7,7 @@ from typing import Any, AsyncIterable
 
 from bidict import bidict
 from dateutil.parser import parse as dateparse
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 import hummingbot.connector.exchange.btc_markets.btc_markets_constants as CONSTANTS
 import hummingbot.connector.exchange.btc_markets.btc_markets_utils as utils
@@ -28,7 +29,6 @@ from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 s_logger = None
 s_decimal_0 = Decimal(0)

--- a/hummingbot/connector/exchange/btc_markets/btc_markets_web_utils.py
+++ b/hummingbot/connector/exchange/btc_markets/btc_markets_web_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from dateutil.parser import parse as dateparse
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 import hummingbot.connector.exchange.btc_markets.btc_markets_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
@@ -10,7 +11,6 @@ from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/bybit/bybit_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/bybit/bybit_api_order_book_data_source.py
@@ -5,6 +5,8 @@ import time
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Mapping
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.bybit.bybit_constants as CONSTANTS
 from hummingbot.connector.exchange.bybit import bybit_web_utils as web_utils
 from hummingbot.connector.exchange.bybit.bybit_order_book import BybitOrderBook
@@ -15,7 +17,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.bybit.bybit_exchange import BybitExchange

--- a/hummingbot/connector/exchange/bybit/bybit_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/bybit/bybit_api_user_stream_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import logging
 import time
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.bybit.bybit_constants as CONSTANTS
 import hummingbot.connector.exchange.bybit.bybit_web_utils as web_utils
 from hummingbot.connector.exchange.bybit.bybit_auth import BybitAuth
@@ -13,7 +15,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class BybitAPIUserStreamDataSource(UserStreamTrackerDataSource):

--- a/hummingbot/connector/exchange/bybit/bybit_exchange.py
+++ b/hummingbot/connector/exchange/bybit/bybit_exchange.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 
 import pandas as pd
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 import hummingbot.connector.exchange.bybit.bybit_constants as CONSTANTS
 import hummingbot.connector.exchange.bybit.bybit_web_utils as web_utils
@@ -22,7 +23,6 @@ from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 s_logger = None
 s_decimal_NaN = Decimal("nan")

--- a/hummingbot/connector/exchange/bybit/bybit_web_utils.py
+++ b/hummingbot/connector/exchange/bybit/bybit_web_utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.bybit.bybit_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
@@ -9,7 +11,6 @@ from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest
 from hummingbot.core.web_assistant.rest_pre_processors import RESTPreProcessorBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class HeadersContentRESTPreProcessor(RESTPreProcessorBase):

--- a/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_api_order_book_data_source.py
@@ -6,6 +6,8 @@ import time
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.coinbase_advanced_trade.coinbase_advanced_trade_constants as constants
 import hummingbot.connector.exchange.coinbase_advanced_trade.coinbase_advanced_trade_web_utils as web_utils
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
@@ -13,7 +15,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.coinbase_advanced_trade.coinbase_advanced_trade_exchange import (

--- a/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_api_user_stream_data_source.py
@@ -5,6 +5,8 @@ import logging
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, AsyncGenerator, NamedTuple
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.coinbase_advanced_trade.coinbase_advanced_trade_constants as constants
 from hummingbot.connector.exchange.coinbase_advanced_trade.coinbase_advanced_trade_web_utils import (
     get_timestamp_from_exchange_time,
@@ -14,7 +16,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.coinbase_advanced_trade.coinbase_advanced_trade_exchange import (  # noqa: F401

--- a/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_exchange.py
+++ b/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_exchange.py
@@ -8,6 +8,7 @@ from typing import Any, AsyncGenerator, AsyncIterable, Iterable
 
 from async_timeout import timeout
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 import hummingbot.connector.exchange.coinbase_advanced_trade.coinbase_advanced_trade_constants as constants
 import hummingbot.connector.exchange.coinbase_advanced_trade.coinbase_advanced_trade_web_utils as web_utils
@@ -42,7 +43,6 @@ from hummingbot.core.event.events import MarketEvent, OrderFilledEvent
 from hummingbot.core.utils.async_utils import safe_gather
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class CoinbaseAdvancedTradeExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_web_utils.py
+++ b/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_web_utils.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import re
 from typing import Callable, Dict, NamedTuple, Tuple
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.coinbase_advanced_trade.coinbase_advanced_trade_constants as constants
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, domain: str = constants.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/cube/cube_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/cube/cube_api_order_book_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import time
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.cube import cube_constants as CONSTANTS, cube_web_utils as web_utils
 from hummingbot.connector.exchange.cube.cube_order_book import CubeOrderBook
 from hummingbot.connector.exchange.cube.cube_ws_protobufs import market_data_pb2
@@ -15,7 +17,6 @@ from hummingbot.core.utils.async_utils import safe_gather
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSBinaryRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.cube.cube_exchange import CubeExchange

--- a/hummingbot/connector/exchange/cube/cube_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/cube/cube_api_user_stream_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import time
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.cube import cube_constants as CONSTANTS
 from hummingbot.connector.exchange.cube.cube_auth import CubeAuth
 from hummingbot.connector.exchange.cube.cube_ws_protobufs import trade_pb2
@@ -11,7 +13,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.web_assistant.connections.data_types import WSBinaryRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.cube.cube_exchange import CubeExchange

--- a/hummingbot/connector/exchange/cube/cube_exchange.py
+++ b/hummingbot/connector/exchange/cube/cube_exchange.py
@@ -6,6 +6,7 @@ from decimal import ROUND_DOWN, Decimal
 from typing import Any, Mapping
 
 from bidict import ValueDuplicationError, bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.exchange.cube import cube_constants as CONSTANTS, cube_utils, cube_web_utils as web_utils
@@ -25,7 +26,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.tracking_nonce import NonceCreator
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class CubeExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/cube/cube_web_utils.py
+++ b/hummingbot/connector/exchange/cube/cube_web_utils.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import time
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.cube.cube_constants as CONSTANTS
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/derive/derive_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/derive/derive_api_order_book_data_source.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 # from bidict import bidict
 from hummingbot.connector.exchange.derive import derive_constants as CONSTANTS, derive_web_utils as web_utils
 from hummingbot.core.data_type.common import TradeType
@@ -11,7 +13,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.derive.derive_exchange import DeriveExchange

--- a/hummingbot/connector/exchange/derive/derive_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/derive/derive_api_user_stream_data_source.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.derive import derive_constants as CONSTANTS, derive_web_utils as web_utils
 from hummingbot.connector.exchange.derive.derive_auth import DeriveAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
@@ -12,7 +14,6 @@ from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSResponse
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.derive.derive_exchange import DeriveExchange

--- a/hummingbot/connector/exchange/derive/derive_exchange.py
+++ b/hummingbot/connector/exchange/derive/derive_exchange.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from typing import Any, AsyncIterable, List
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import SECOND, TWELVE_HOURS, s_decimal_NaN
 from hummingbot.connector.exchange.derive import derive_constants as CONSTANTS, derive_web_utils as web_utils
@@ -25,7 +26,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.event.events import MarketEvent, OrderFilledEvent
 from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
 from hummingbot.core.utils.estimate_fee import build_trade_fee
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class DeriveExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/derive/derive_web_utils.py
+++ b/hummingbot/connector/exchange/derive/derive_web_utils.py
@@ -6,13 +6,14 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.derive.derive_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 MAX_INT_256 = 2**255 - 1
 MIN_INT_256 = -(2**255)

--- a/hummingbot/connector/exchange/dexalot/dexalot_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/dexalot/dexalot_api_order_book_data_source.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.dexalot import dexalot_constants as CONSTANTS, dexalot_web_utils as web_utils
 from hummingbot.core.data_type.common import TradeType
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
@@ -14,7 +16,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.dexalot.dexalot_exchange import DexalotExchange

--- a/hummingbot/connector/exchange/dexalot/dexalot_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/dexalot/dexalot_api_user_stream_data_source.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.dexalot import dexalot_constants as CONSTANTS, dexalot_web_utils as web_utils
 from hummingbot.connector.exchange.dexalot.dexalot_auth import DexalotAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class DexalotAPIUserStreamDataSource(UserStreamTrackerDataSource):

--- a/hummingbot/connector/exchange/dexalot/dexalot_exchange.py
+++ b/hummingbot/connector/exchange/dexalot/dexalot_exchange.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Tuple
 import dateutil.parser as dp
 from async_timeout import timeout
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.exchange.dexalot import (
@@ -33,7 +34,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class DexalotExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/dexalot/dexalot_web_utils.py
+++ b/hummingbot/connector/exchange/dexalot/dexalot_web_utils.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import time
 from typing import Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.dexalot.dexalot_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/foxbit/foxbit_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/foxbit/foxbit_api_order_book_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import time
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.foxbit import (
     foxbit_constants as CONSTANTS,
     foxbit_utils as utils,
@@ -20,7 +22,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.foxbit.foxbit_exchange import FoxbitExchange

--- a/hummingbot/connector/exchange/foxbit/foxbit_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/foxbit/foxbit_api_user_stream_data_source.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.foxbit import (
     foxbit_constants as CONSTANTS,
     foxbit_utils as utils,
@@ -13,7 +15,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.foxbit.foxbit_exchange import FoxbitExchange

--- a/hummingbot/connector/exchange/foxbit/foxbit_exchange.py
+++ b/hummingbot/connector/exchange/foxbit/foxbit_exchange.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from typing import Any, Mapping
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.exchange.foxbit import (
@@ -30,7 +31,6 @@ from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSResponse
 from hummingbot.core.web_assistant.rest_assistant import RESTAssistant
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 s_logger = None
 s_decimal_0 = Decimal(0)

--- a/hummingbot/connector/exchange/foxbit/foxbit_web_utils.py
+++ b/hummingbot/connector/exchange/foxbit/foxbit_web_utils.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.foxbit.foxbit_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(

--- a/hummingbot/connector/exchange/gate_io/gate_io_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_api_order_book_data_source.py
@@ -5,6 +5,8 @@ import json
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.gate_io import gate_io_constants as CONSTANTS, gate_io_web_utils as web_utils
 from hummingbot.core.data_type.common import TradeType
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
@@ -12,7 +14,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.gate_io.gate_io_exchange import GateIoExchange

--- a/hummingbot/connector/exchange/gate_io/gate_io_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_api_user_stream_data_source.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.gate_io import gate_io_constants as CONSTANTS
 from hummingbot.connector.exchange.gate_io.gate_io_auth import GateIoAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.gate_io.gate_io_exchange import GateIoExchange

--- a/hummingbot/connector/exchange/gate_io/gate_io_exchange.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_exchange.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import Any
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.exchange.gate_io import gate_io_constants as CONSTANTS, gate_io_web_utils as web_utils
@@ -20,7 +21,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount, TradeFeeBase
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class GateIoExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/gate_io/gate_io_web_utils.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_web_utils.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.gate_io.gate_io_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(endpoint: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/htx/htx_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/htx/htx_api_order_book_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import uuid
 from typing import TYPE_CHECKING, Any, Dict
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.htx.htx_constants as CONSTANTS
 from hummingbot.connector.exchange.htx.htx_web_utils import public_rest_url
 from hummingbot.core.data_type.common import TradeType
@@ -12,7 +14,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.htx.htx_exchange import HtxExchange

--- a/hummingbot/connector/exchange/htx/htx_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/htx/htx_api_user_stream_data_source.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.htx.htx_constants as CONSTANTS
 from hummingbot.connector.exchange.htx.htx_auth import HtxAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSResponse
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.htx.htx_exchange import HtxExchange

--- a/hummingbot/connector/exchange/htx/htx_exchange.py
+++ b/hummingbot/connector/exchange/htx/htx_exchange.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import Any, AsyncIterable
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 import hummingbot.connector.exchange.htx.htx_constants as CONSTANTS
 from hummingbot.connector.constants import s_decimal_0, s_decimal_NaN
@@ -22,7 +23,6 @@ from hummingbot.core.data_type.trade_fee import TokenAmount, TradeFeeBase
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.estimate_fee import build_trade_fee
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class HtxExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/htx/htx_web_utils.py
+++ b/hummingbot/connector/exchange/htx/htx_web_utils.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from typing import Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.htx.htx_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import GZipCompressionWSPostProcessor, TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, domain: str = None) -> str:

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_api_order_book_data_source.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 # from bidict import bidict
 from hummingbot.connector.exchange.hyperliquid import (
     hyperliquid_constants as CONSTANTS,
@@ -14,7 +16,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.hyperliquid.hyperliquid_exchange import HyperliquidExchange

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_api_user_stream_data_source.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.hyperliquid import (
     hyperliquid_constants as CONSTANTS,
     hyperliquid_web_utils as web_utils,
@@ -13,7 +15,6 @@ from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.hyperliquid.hyperliquid_exchange import HyperliquidExchange

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_web_utils.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_web_utils.py
@@ -4,12 +4,13 @@ import time
 from decimal import Decimal
 from typing import Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.hyperliquid.hyperliquid_constants as CONSTANTS
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTRequest
 from hummingbot.core.web_assistant.rest_pre_processors import RESTPreProcessorBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class HyperliquidPerpetualRESTPreProcessor(RESTPreProcessorBase):

--- a/hummingbot/connector/exchange/injective_v2/injective_v2_exchange.py
+++ b/hummingbot/connector/exchange/injective_v2/injective_v2_exchange.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Any, Callable, Union
 
 from async_timeout import timeout
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.client_order_tracker import ClientOrderTracker
 from hummingbot.connector.constants import s_decimal_NaN
@@ -39,7 +40,6 @@ from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.core.web_assistant.auth import AuthBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class InjectiveV2Exchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/kraken/kraken_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/kraken/kraken_api_order_book_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import time
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.kraken import kraken_constants as CONSTANTS, kraken_web_utils as web_utils
 from hummingbot.connector.exchange.kraken.kraken_order_book import KrakenOrderBook
 from hummingbot.connector.exchange.kraken.kraken_utils import (
@@ -17,7 +19,6 @@ from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJ
 from hummingbot.core.web_assistant.rest_assistant import RESTAssistant
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.kraken.kraken_exchange import KrakenExchange

--- a/hummingbot/connector/exchange/kraken/kraken_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/kraken/kraken_api_user_stream_data_source.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.kraken import kraken_constants as CONSTANTS
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.kraken.kraken_exchange import KrakenExchange

--- a/hummingbot/connector/exchange/kraken/kraken_exchange.py
+++ b/hummingbot/connector/exchange/kraken/kraken_exchange.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from typing import Any, List
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.exchange.kraken import kraken_constants as CONSTANTS, kraken_web_utils as web_utils
@@ -32,7 +33,6 @@ from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.core.utils.tracking_nonce import NonceCreator
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class KrakenExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/kraken/kraken_web_utils.py
+++ b/hummingbot/connector/exchange/kraken/kraken_web_utils.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import time
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.kraken.kraken_constants as CONSTANTS
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def private_rest_url(*args, **kwargs) -> str:

--- a/hummingbot/connector/exchange/kucoin/kucoin_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/kucoin/kucoin_api_order_book_data_source.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.kucoin import kucoin_constants as CONSTANTS, kucoin_web_utils as web_utils
 from hummingbot.core.data_type.common import TradeType
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
@@ -10,7 +12,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.kucoin.kucoin_exchange import KucoinExchange

--- a/hummingbot/connector/exchange/kucoin/kucoin_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/kucoin/kucoin_api_user_stream_data_source.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.kucoin import kucoin_constants as CONSTANTS, kucoin_web_utils as web_utils
 from hummingbot.connector.exchange.kucoin.kucoin_auth import KucoinAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.kucoin.kucoin_exchange import KucoinExchange

--- a/hummingbot/connector/exchange/kucoin/kucoin_exchange.py
+++ b/hummingbot/connector/exchange/kucoin/kucoin_exchange.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import Any
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.exchange.kucoin import (
@@ -25,7 +26,6 @@ from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class KucoinExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/kucoin/kucoin_web_utils.py
+++ b/hummingbot/connector/exchange/kucoin/kucoin_web_utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.kucoin import kucoin_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
@@ -9,7 +11,6 @@ from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/mexc/mexc_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/mexc/mexc_api_order_book_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import time
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.mexc import mexc_constants as CONSTANTS, mexc_web_utils as web_utils
 from hummingbot.connector.exchange.mexc.mexc_order_book import MexcOrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
@@ -11,7 +13,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.mexc.mexc_exchange import MexcExchange

--- a/hummingbot/connector/exchange/mexc/mexc_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/mexc/mexc_api_user_stream_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import time
 from typing import TYPE_CHECKING
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.mexc import mexc_constants as CONSTANTS, mexc_web_utils as web_utils
 from hummingbot.connector.exchange.mexc.mexc_auth import MexcAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
@@ -11,7 +13,6 @@ from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.mexc.mexc_exchange import MexcExchange

--- a/hummingbot/connector/exchange/mexc/mexc_exchange.py
+++ b/hummingbot/connector/exchange/mexc/mexc_exchange.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import Any
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.exchange.mexc import mexc_constants as CONSTANTS, mexc_utils, mexc_web_utils as web_utils
@@ -22,7 +23,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.event.events import MarketEvent, OrderFilledEvent
 from hummingbot.core.utils.async_utils import safe_gather
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class MexcExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/mexc/mexc_web_utils.py
+++ b/hummingbot/connector/exchange/mexc/mexc_web_utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
 from hummingbot.connector.exchange.mexc.mexc_post_processor import MexcPostProcessor
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
@@ -9,7 +11,6 @@ from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/ndax/ndax_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/ndax/ndax_api_order_book_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 import time
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.ndax import ndax_constants as CONSTANTS, ndax_web_utils as web_utils
 from hummingbot.connector.exchange.ndax.ndax_order_book import NdaxOrderBook
 from hummingbot.connector.exchange.ndax.ndax_order_book_message import NdaxOrderBookEntry
@@ -12,7 +14,6 @@ from hummingbot.core.data_type.order_book_message import OrderBookMessage
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.ndax.ndax_exchange import NdaxExchange

--- a/hummingbot/connector/exchange/ndax/ndax_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/ndax/ndax_api_user_stream_data_source.py
@@ -4,13 +4,14 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.ndax import ndax_constants as CONSTANTS
 from hummingbot.connector.exchange.ndax.ndax_auth import NdaxAuth
 from hummingbot.connector.exchange.ndax.ndax_websocket_adaptor import NdaxWebSocketAdaptor
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.ndax.ndax_exchange import NdaxExchange

--- a/hummingbot/connector/exchange/ndax/ndax_exchange.py
+++ b/hummingbot/connector/exchange/ndax/ndax_exchange.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import Any
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.exchange.ndax import ndax_constants as CONSTANTS, ndax_utils, ndax_web_utils as web_utils
 from hummingbot.connector.exchange.ndax.ndax_api_order_book_data_source import NdaxAPIOrderBookDataSource
@@ -22,7 +23,6 @@ from hummingbot.core.data_type.user_stream_tracker_data_source import UserStream
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.tracking_nonce import NonceCreator
 from hummingbot.core.web_assistant.connections.data_types import RESTRequest
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 s_decimal_NaN = Decimal("nan")
 s_decimal_0 = Decimal(0)

--- a/hummingbot/connector/exchange/ndax/ndax_web_utils.py
+++ b/hummingbot/connector/exchange/ndax/ndax_web_utils.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import time
 from typing import Callable
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.ndax.ndax_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/okx/okx_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/okx/okx_api_order_book_data_source.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.okx import okx_constants as CONSTANTS, okx_web_utils as web_utils
 from hummingbot.core.data_type.common import TradeType
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
@@ -10,7 +12,6 @@ from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTr
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest, WSPlainTextRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.okx.okx_exchange import OkxExchange

--- a/hummingbot/connector/exchange/okx/okx_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/okx/okx_api_user_stream_data_source.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.okx import okx_constants as CONSTANTS
 from hummingbot.connector.exchange.okx.okx_auth import OkxAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSPlainTextRequest, WSResponse
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.okx.okx_exchange import OkxExchange

--- a/hummingbot/connector/exchange/okx/okx_exchange.py
+++ b/hummingbot/connector/exchange/okx/okx_exchange.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import Any
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.exchange.okx import okx_constants as CONSTANTS, okx_utils, okx_web_utils as web_utils
 from hummingbot.connector.exchange.okx.okx_api_order_book_data_source import OkxAPIOrderBookDataSource
@@ -21,7 +22,6 @@ from hummingbot.core.data_type.trade_fee import TokenAmount, TradeFeeBase
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class OkxExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/okx/okx_web_utils.py
+++ b/hummingbot/connector/exchange/okx/okx_web_utils.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from typing import Callable
 from urllib.parse import urljoin
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.okx.okx_constants as CONSTANTS
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/vertex/vertex_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/vertex/vertex_api_order_book_data_source.py
@@ -4,6 +4,8 @@ import asyncio
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.vertex import (
     vertex_constants as CONSTANTS,
     vertex_utils as utils,
@@ -15,7 +17,6 @@ from hummingbot.core.data_type.order_book_message import OrderBookMessage
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.vertex.vertex_exchange import VertexExchange

--- a/hummingbot/connector/exchange/vertex/vertex_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/vertex/vertex_api_user_stream_data_source.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.exchange.vertex import (
     vertex_constants as CONSTANTS,
     vertex_utils as utils,
@@ -13,7 +15,6 @@ from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.vertex.vertex_exchange import VertexExchange

--- a/hummingbot/connector/exchange/vertex/vertex_exchange.py
+++ b/hummingbot/connector/exchange/vertex/vertex_exchange.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import Any
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.constants import s_decimal_0, s_decimal_NaN
 from hummingbot.connector.exchange.vertex import (
@@ -27,7 +28,6 @@ from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class VertexExchange(ExchangePyBase):

--- a/hummingbot/connector/exchange/vertex/vertex_web_utils.py
+++ b/hummingbot/connector/exchange/vertex/vertex_web_utils.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import time
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 import hummingbot.connector.exchange.vertex.vertex_constants as CONSTANTS
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.auth import AuthBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/hummingbot/connector/exchange/xrpl/xrpl_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/xrpl/xrpl_api_order_book_data_source.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 # XRPL imports
 from xrpl.asyncio.clients import AsyncWebsocketClient
 from xrpl.models.requests import BookOffers, Subscribe, SubscribeBook
@@ -21,7 +23,6 @@ from hummingbot.core.data_type.order_book_message import OrderBookMessage
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
 from hummingbot.core.utils.async_utils import safe_gather
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 if TYPE_CHECKING:
     from hummingbot.connector.exchange.xrpl.xrpl_exchange import XrplExchange

--- a/hummingbot/connector/exchange/xrpl/xrpl_exchange.py
+++ b/hummingbot/connector/exchange/xrpl/xrpl_exchange.py
@@ -8,6 +8,7 @@ from decimal import ROUND_DOWN, Decimal
 from typing import Any, Callable, Dict, Mapping, Union, cast
 
 from bidict import bidict
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 # XRPL Imports
 from xrpl.asyncio.clients import Client, XRPLRequestFailureException
@@ -88,7 +89,6 @@ from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TradeFeeBas
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.tracking_nonce import NonceCreator
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class XRPLOrderTracker(ClientOrderTracker):

--- a/hummingbot/connector/exchange_py_base.py
+++ b/hummingbot/connector/exchange_py_base.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from typing import Any, AsyncIterable, Callable
 
 from async_timeout import timeout
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.client_order_tracker import ClientOrderTracker
 from hummingbot.connector.constants import MINUTE, TWELVE_HOURS, s_decimal_0, s_decimal_NaN
@@ -33,7 +34,6 @@ from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class ExchangePyBase(ExchangeBase, ABC):

--- a/hummingbot/connector/test_support/exchange_connector_test.py
+++ b/hummingbot/connector/test_support/exchange_connector_test.py
@@ -5,7 +5,6 @@ import json
 import re
 from abc import ABC, abstractmethod
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any, Awaitable, Callable, Union
 from unittest.mock import AsyncMock, patch
 
@@ -29,6 +28,7 @@ from hummingbot.core.event.events import (
     SellOrderCreatedEvent,
 )
 from hummingbot.core.network_iterator import NetworkStatus
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class AbstractExchangeConnectorTests:

--- a/hummingbot/connector/test_support/network_mocking_assistant.py
+++ b/hummingbot/connector/test_support/network_mocking_assistant.py
@@ -10,9 +10,9 @@ from typing import Any, Union
 from unittest.mock import AsyncMock, PropertyMock
 
 import aiohttp
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.logger import HummingbotLogger
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 def get_stable_key(ws: AsyncMock) -> uuid.UUID:

--- a/hummingbot/connector/utilities/oms_connector/oms_connector_web_utils.py
+++ b/hummingbot/connector/utilities/oms_connector/oms_connector_web_utils.py
@@ -4,13 +4,14 @@ import json
 import time
 from abc import ABC, abstractmethod
 
+from web_assistant.web_assistants_factory import WebAssistantsFactory
+
 from hummingbot.connector.utilities.oms_connector import oms_connector_constants as CONSTANTS
 from hummingbot.connector.utilities.oms_connector.oms_connector_auth import OMSConnectorAuth
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.connections.data_types import WSRequest, WSResponse
 from hummingbot.core.web_assistant.ws_post_processors import WSPostProcessorBase
 from hummingbot.core.web_assistant.ws_pre_processors import WSPreProcessorBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
 class OMSConnectorURLCreatorBase(ABC):

--- a/hummingbot/connector/utils.py
+++ b/hummingbot/connector/utils.py
@@ -9,6 +9,7 @@ from hashlib import md5
 from typing import Any, Callable
 
 from hexbytes import HexBytes
+from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
@@ -17,7 +18,6 @@ from hummingbot.core.utils.tracking_nonce import NonceCreator, get_tracking_nonc
 from hummingbot.core.web_assistant.connections.data_types import RESTRequest, WSResponse
 from hummingbot.core.web_assistant.rest_pre_processors import RESTPreProcessorBase
 from hummingbot.core.web_assistant.ws_post_processors import WSPostProcessorBase
-from web_assistant.web_assistants_factory import WebAssistantsFactory
 
 TradeFillOrderDetails = namedtuple("TradeFillOrderDetails", "market exchange_trade_id symbol")
 

--- a/hummingbot/core/utils/trading_pair_fetcher.py
+++ b/hummingbot/core/utils/trading_pair_fetcher.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Awaitable, Callable
 
 from async_utils.core import safe_ensure_future
+
 from hummingbot.client.config.config_helpers import ClientConfigAdapter
 from hummingbot.client.settings import AllConnectorSettings, ConnectorSetting
 from hummingbot.logger import HummingbotLogger

--- a/hummingbot/strategy/strategy_v2_base.py
+++ b/hummingbot/strategy/strategy_v2_base.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 import yaml
 from pydantic import BaseModel, Field, field_validator
+from remote_iface import ETopicPublisher
 
 from hummingbot.client import settings
 from hummingbot.client.config.config_data_types import BaseClientModel
@@ -43,7 +44,6 @@ from hummingbot.strategy_v2.models.executor_actions import (
     StoreExecutorAction,
 )
 from hummingbot.strategy_v2.models.executors_info import ExecutorInfo
-from remote_iface import ETopicPublisher
 
 lsb_logger = None
 s_decimal_nan = Decimal("NaN")

--- a/pixi.lock
+++ b/pixi.lock
@@ -122,7 +122,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/injective-py-1.14.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/isort-8.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonalias-0.1.1-pyhd8ed1ab_0.conda
@@ -461,7 +460,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/injective-py-1.14.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/isort-8.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonalias-0.1.1-pyhd8ed1ab_0.conda
@@ -2112,16 +2110,6 @@ packages:
   license_family: APACHE
   size: 592565
   timestamp: 1777521517573
-- conda: https://conda.anaconda.org/conda-forge/noarch/isort-8.0.1-pyhd8ed1ab_0.conda
-  sha256: cc5c2b513143ea9675ba5b3570182f7568fd1029b299ee3bc58424dcce8c5539
-  md5: 98cdd8615792e90da1023bc546f806d9
-  depends:
-  - importlib-metadata >=4.6.0
-  - python >=3.10,<4.0
-  license: MIT
-  license_family: MIT
-  size: 72146
-  timestamp: 1772278531671
 - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
   sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
   md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,6 @@ pytest-timeout = ">=2.1.0"
 coverage = ">=7.2.7"
 diff-cover = ">=7.7.0"
 ruff = "==0.15.7"
-isort = ">=5.12.0"
 mypy = "*"
 pre-commit = ">=3.3.3"
 cython-lint = "*"
@@ -146,7 +145,7 @@ test-unit = { cmd = "pytest test/hummingbot", depends-on = ["build"] }
 test-fast = "pytest --timeout=30 --tb=short -q"
 lint = "ruff check hummingbot test controllers scripts"
 lint-cython = "cython-lint hummingbot"
-format = { cmd = "ruff format hummingbot test controllers scripts && isort hummingbot test controllers scripts" }
+format = { cmd = "ruff format hummingbot test controllers scripts" }
 format-check = "ruff format --check hummingbot test controllers scripts"
 type-check = "mypy hummingbot"
 security-scan = "bandit -c pyproject.toml -r hummingbot/"
@@ -163,25 +162,19 @@ compat-check = { depends-on = ["compat-import", "compat-contract", "compat-integ
 migrate-pytest = { cmd = "python $HOME/PycharmProjects/refactor-applications/refactor/rules/pytest_migration.py -d --apply --verbose test/", env = { PYTHONPATH = "$HOME/PycharmProjects/refactor-applications:$PYTHONPATH" } }
 migrate-pytest-dry = { cmd = "python $HOME/PycharmProjects/refactor-applications/refactor/rules/pytest_migration.py -d --verbose test/", env = { PYTHONPATH = "$HOME/PycharmProjects/refactor-applications:$PYTHONPATH" } }
 
-[tool.isort]
-line_length = 120
-multi_line_output = 3
-include_trailing_comma = true
-use_parentheses = true
-ensure_newline_before_comments = true
-combine_as_imports = true
-filter_files = true
-skip = ["setup.py"]
-known_first_party = ["hummingbot", "async_utils", "candles_feed", "connector_utils", "data_type_primitives", "event_bus", "liquidations_feed", "logger", "market_connector", "market_data", "market_simulator", "rate_oracle", "remote_iface", "strategy_framework", "web_assistant"]
-
 [tool.ruff]
 line-length = 120
 target-version = "py312"
 include = ["hummingbot/**/*.py", "test/**/*.py"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W"]
+select = ["E", "F", "W", "I"]
 ignore = ["E251", "E501", "E702"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["hummingbot"]
+combine-as-imports = true
+force-single-line = false
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]

--- a/test/hummingbot/client/command/test_balance_command.py
+++ b/test/hummingbot/client/command/test_balance_command.py
@@ -1,12 +1,12 @@
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.mock.mock_cli import CLIMockingAssistant
 from typing import Awaitable
 from unittest.mock import AsyncMock, patch
 
 from hummingbot.client.config.config_helpers import read_system_configs_from_yml
 from hummingbot.client.hummingbot_application import HummingbotApplication
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.mock.mock_cli import CLIMockingAssistant
 
 
 class BalanceCommandTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/client/command/test_config_command.py
+++ b/test/hummingbot/client/command/test_config_command.py
@@ -1,6 +1,4 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.mock.mock_cli import CLIMockingAssistant
 from typing import Union
 from unittest.mock import patch
 
@@ -11,6 +9,8 @@ from hummingbot.client.config.config_helpers import ClientConfigAdapter, read_sy
 from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.strategy_config_data_types import BaseStrategyConfigMap
 from hummingbot.client.hummingbot_application import HummingbotApplication
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.mock.mock_cli import CLIMockingAssistant
 
 
 class ConfigCommandTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/client/command/test_connect_command.py
+++ b/test/hummingbot/client/command/test_connect_command.py
@@ -1,6 +1,4 @@
 import asyncio
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.mock.mock_cli import CLIMockingAssistant
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
@@ -9,6 +7,8 @@ from hummingbot.client.config.client_config_map import ClientConfigMap, DBSqlite
 from hummingbot.client.config.config_helpers import ClientConfigAdapter, read_system_configs_from_yml
 from hummingbot.client.config.security import Security
 from hummingbot.client.hummingbot_application import HummingbotApplication
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.mock.mock_cli import CLIMockingAssistant
 
 
 class ConnectCommandTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/client/command/test_create_command.py
+++ b/test/hummingbot/client/command/test_create_command.py
@@ -1,7 +1,5 @@
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.mock.mock_cli import CLIMockingAssistant
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from hummingbot.client.config.client_config_map import ClientConfigMap
@@ -11,6 +9,8 @@ from hummingbot.client.config.config_helpers import (
     read_system_configs_from_yml,
 )
 from hummingbot.client.hummingbot_application import HummingbotApplication
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.mock.mock_cli import CLIMockingAssistant
 
 
 class CreateCommandTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/client/command/test_history_command.py
+++ b/test/hummingbot/client/command/test_history_command.py
@@ -3,8 +3,6 @@ import datetime
 import time
 from decimal import Decimal
 from pathlib import Path
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.mock.mock_cli import CLIMockingAssistant
 from unittest.mock import patch
 
 from hummingbot.client.config.client_config_map import ClientConfigMap, DBSqliteMode
@@ -15,6 +13,8 @@ from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee
 from hummingbot.model.order import Order
 from hummingbot.model.sql_connection_manager import SQLConnectionManager
 from hummingbot.model.trade_fill import TradeFill
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.mock.mock_cli import CLIMockingAssistant
 
 
 class HistoryCommandTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/client/command/test_import_command.py
+++ b/test/hummingbot/client/command/test_import_command.py
@@ -3,8 +3,6 @@ from datetime import date, datetime, time
 from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.mock.mock_cli import CLIMockingAssistant
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pydantic import Field
@@ -16,6 +14,8 @@ from hummingbot.client.config.config_helpers import ClientConfigAdapter, read_sy
 from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.strategy_config_data_types import BaseTradingStrategyConfigMap
 from hummingbot.client.hummingbot_application import HummingbotApplication
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.mock.mock_cli import CLIMockingAssistant
 
 
 class ImportCommandTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/client/command/test_order_book_command.py
+++ b/test/hummingbot/client/command/test_order_book_command.py
@@ -1,5 +1,3 @@
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.mock.mock_cli import CLIMockingAssistant
 from unittest.mock import patch
 
 import pytest
@@ -8,6 +6,8 @@ from hummingbot.client.config.client_config_map import ClientConfigMap, DBSqlite
 from hummingbot.client.config.config_helpers import ClientConfigAdapter, read_system_configs_from_yml
 from hummingbot.client.hummingbot_application import HummingbotApplication
 from hummingbot.connector.test_support.mock_paper_exchange import MockPaperExchange
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.mock.mock_cli import CLIMockingAssistant
 
 
 class OrderBookCommandTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/client/command/test_rate_command.py
+++ b/test/hummingbot/client/command/test_rate_command.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from copy import deepcopy
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.mock.mock_cli import CLIMockingAssistant
 from unittest.mock import patch
 
 import pytest
@@ -13,6 +11,8 @@ from hummingbot.client.hummingbot_application import HummingbotApplication
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.rate_oracle import RateOracle
 from hummingbot.core.rate_oracle.sources.rate_source_base import RateSourceBase
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.mock.mock_cli import CLIMockingAssistant
 
 
 class DummyRateSource(RateSourceBase):

--- a/test/hummingbot/client/command/test_status_command.py
+++ b/test/hummingbot/client/command/test_status_command.py
@@ -1,6 +1,4 @@
 import asyncio
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.mock.mock_cli import CLIMockingAssistant
 from unittest.mock import patch
 
 import pytest
@@ -8,6 +6,8 @@ import pytest
 from hummingbot.client.config.client_config_map import ClientConfigMap
 from hummingbot.client.config.config_helpers import ClientConfigAdapter, read_system_configs_from_yml
 from hummingbot.client.hummingbot_application import HummingbotApplication
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.mock.mock_cli import CLIMockingAssistant
 
 
 class StatusCommandTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/client/command/test_ticker_command.py
+++ b/test/hummingbot/client/command/test_ticker_command.py
@@ -1,5 +1,3 @@
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.mock.mock_cli import CLIMockingAssistant
 from unittest.mock import patch
 
 import pytest
@@ -8,6 +6,8 @@ from hummingbot.client.config.client_config_map import ClientConfigMap, DBSqlite
 from hummingbot.client.config.config_helpers import ClientConfigAdapter, read_system_configs_from_yml
 from hummingbot.client.hummingbot_application import HummingbotApplication
 from hummingbot.connector.test_support.mock_paper_exchange import MockPaperExchange
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.mock.mock_cli import CLIMockingAssistant
 
 
 class TickerCommandTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/aevo_perpetual/test_aevo_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/aevo_perpetual/test_aevo_perpetual_api_order_book_data_source.py
@@ -1,6 +1,5 @@
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock
 
 from bidict import bidict
@@ -14,6 +13,7 @@ from hummingbot.core.data_type.common import TradeType
 from hummingbot.core.data_type.funding_info import FundingInfo, FundingInfoUpdate
 from hummingbot.core.data_type.order_book_message import OrderBookMessageType
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class AevoPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/aevo_perpetual/test_aevo_perpetual_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/aevo_perpetual/test_aevo_perpetual_api_user_stream_data_source.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bidict import bidict
@@ -14,6 +13,7 @@ from hummingbot.connector.derivative.aevo_perpetual.aevo_perpetual_auth import A
 from hummingbot.connector.derivative.aevo_perpetual.aevo_perpetual_derivative import AevoPerpetualDerivative
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSResponse
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class AevoPerpetualAPIUserStreamDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/aevo_perpetual/test_aevo_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/aevo_perpetual/test_aevo_perpetual_derivative.py
@@ -1,6 +1,5 @@
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest import TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,6 +14,7 @@ from hummingbot.core.data_type.common import OrderType, PositionAction, Position
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
 from hummingbot.core.data_type.trade_fee import TokenAmount
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class AevoPerpetualDerivativeTests(TestCase):

--- a/test/hummingbot/connector/derivative/architect_perpetual/test_architect_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/architect_perpetual/test_architect_perpetual_api_order_book_data_source.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Union
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -24,6 +23,7 @@ from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.data_type.funding_info import FundingInfo
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class ArchitectPerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/architect_perpetual/test_architecture_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/architect_perpetual/test_architecture_perpetual_user_stream_data_source.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, patch
 
 from aioresponses import aioresponses
@@ -22,6 +21,7 @@ from hummingbot.connector.derivative.architect_perpetual.architect_perpetual_use
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class ArchitecturePerpetualUserStreamDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/backpack_perpetual/test_backpack_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/backpack_perpetual/test_backpack_perpetual_api_order_book_data_source.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses.core import aioresponses
@@ -20,6 +19,7 @@ from hummingbot.connector.test_support.network_mocking_assistant import NetworkM
 from hummingbot.core.data_type.funding_info import FundingInfo
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BackpackPerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/backpack_perpetual/test_backpack_perpetual_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/backpack_perpetual/test_backpack_perpetual_api_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bidict import bidict
@@ -16,6 +15,7 @@ from hummingbot.connector.derivative.backpack_perpetual.backpack_perpetual_deriv
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BackpackPerpetualAPIUserStreamDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/backpack_perpetual/test_backpack_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/backpack_perpetual/test_backpack_perpetual_derivative.py
@@ -5,7 +5,6 @@ import functools
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any, Callable, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -26,6 +25,7 @@ from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 from hummingbot.core.data_type.trade_fee import TokenAmount
 from hummingbot.core.event.event_logger import EventLogger
 from hummingbot.core.event.events import MarketEvent, OrderFilledEvent
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BackpackPerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_api_order_book_data_source.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,6 +21,7 @@ from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.data_type.funding_info import FundingInfo
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BinancePerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_derivative.py
@@ -5,7 +5,6 @@ import functools
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any, Callable, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -28,6 +27,7 @@ from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.trade_fee import TokenAmount
 from hummingbot.core.event.event_logger import EventLogger
 from hummingbot.core.event.events import MarketEvent, OrderFilledEvent
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BinancePerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -19,6 +18,7 @@ from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_user_st
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BinancePerpetualUserStreamDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/bitget_perpetual/test_bitget_perpetual_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/bitget_perpetual/test_bitget_perpetual_order_book_data_source.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,6 +21,7 @@ from hummingbot.connector.derivative.bitget_perpetual.bitget_perpetual_derivativ
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.funding_info import FundingInfo, FundingInfoUpdate
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BitgetPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/bitget_perpetual/test_bitget_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/bitget_perpetual/test_bitget_perpetual_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -18,6 +17,7 @@ from hummingbot.connector.derivative.bitget_perpetual.bitget_perpetual_auth impo
 from hummingbot.connector.derivative.bitget_perpetual.bitget_perpetual_derivative import BitgetPerpetualDerivative
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BitgetPerpetualUserStreamDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/bitmart_perpetual/test_bitmart_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/bitmart_perpetual/test_bitmart_perpetual_api_order_book_data_source.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,6 +21,7 @@ from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.data_type.funding_info import FundingInfo
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BitmartPerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/bitmart_perpetual/test_bitmart_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/bitmart_perpetual/test_bitmart_perpetual_derivative.py
@@ -5,7 +5,6 @@ import functools
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any, Awaitable, Callable, List
 from unittest.mock import AsyncMock, patch
 
@@ -28,6 +27,7 @@ from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.trade_fee import TokenAmount
 from hummingbot.core.event.event_logger import EventLogger
 from hummingbot.core.event.events import MarketEvent, OrderFilledEvent
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BitmartPerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/bitmart_perpetual/test_bitmart_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/bitmart_perpetual/test_bitmart_perpetual_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, patch
 
 import hummingbot.connector.derivative.bitmart_perpetual.bitmart_perpetual_constants as CONSTANTS
@@ -15,6 +14,7 @@ from hummingbot.connector.derivative.bitmart_perpetual.bitmart_perpetual_user_st
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BitmartPerpetualUserStreamDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_api_order_book_data_source.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -20,6 +19,7 @@ from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_derivative 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.funding_info import FundingInfo, FundingInfoUpdate
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BybitPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_user_stream_data_source.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_constants as CONSTANTS
@@ -10,6 +9,7 @@ from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_user_stream
     BybitPerpetualUserStreamDataSource,
 )
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BybitPerpetualUserStreamDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_api_order_book_data_source.py
@@ -1,6 +1,5 @@
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -18,6 +17,7 @@ from hummingbot.core.web_assistant.connections.rest_connection import RESTConnec
 from hummingbot.core.web_assistant.connections.ws_connection import WSConnection
 from hummingbot.core.web_assistant.rest_assistant import RESTAssistant
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DecibelPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_auth.py
@@ -1,7 +1,7 @@
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import MagicMock, patch
 
 from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_auth import DecibelPerpetualAuth
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DummyRESTRequest:

--- a/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_derivative.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -20,6 +19,7 @@ from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 from hummingbot.core.event.event_logger import EventLogger
 from hummingbot.core.event.events import MarketEvent
 from hummingbot.core.network_iterator import NetworkStatus
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DummyRESTRequest:

--- a/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_transaction_builder.py
+++ b/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_transaction_builder.py
@@ -1,4 +1,3 @@
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_constants as CONSTANTS
@@ -6,6 +5,7 @@ from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_auth im
 from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_transaction_builder import (
     DecibelPerpetualTransactionBuilder,
 )
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 # DecibelWriteDex is imported at module level in transaction_builder
 TX_BUILDER_MODULE = "hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_transaction_builder"

--- a/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_user_stream_data_source.py
@@ -1,5 +1,4 @@
 import asyncio
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -14,6 +13,7 @@ from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.connections.rest_connection import RESTConnection
 from hummingbot.core.web_assistant.connections.ws_connection import WSConnection
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DecibelPerpetualUserStreamDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_web_utils.py
+++ b/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_web_utils.py
@@ -1,5 +1,3 @@
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-
 import hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_constants as CONSTANTS
 from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_web_utils import (
     build_api_factory,
@@ -10,6 +8,7 @@ from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_web_uti
     public_rest_url,
     wss_url,
 )
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestDecibelPerpetualWebUtils(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/derive_perpetual/test_derive_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/derive_perpetual/test_derive_perpetual_api_order_book_data_source.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,6 +21,7 @@ from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.data_type.funding_info import FundingInfo, FundingInfoUpdate
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DeriveAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/derive_perpetual/test_derive_perpetual_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/derive_perpetual/test_derive_perpetual_api_user_stream_data_source.py
@@ -4,7 +4,6 @@ import asyncio
 
 # from datetime import datetime, timezone
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bidict import bidict
@@ -18,6 +17,7 @@ from hummingbot.connector.derivative.derive_perpetual.derive_perpetual_derivativ
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestDerivePerpetualAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/dydx_v4_perpetual/conftest.py
+++ b/test/hummingbot/connector/derivative/dydx_v4_perpetual/conftest.py
@@ -1,3 +1,6 @@
+import importlib.util
+
 import pytest
 
-pytest.importorskip("v4_proto")
+if importlib.util.find_spec("v4_proto") is None:
+    pytest.skip("v4_proto not installed", allow_module_level=True)

--- a/test/hummingbot/connector/derivative/dydx_v4_perpetual/conftest.py
+++ b/test/hummingbot/connector/derivative/dydx_v4_perpetual/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("v4_proto")

--- a/test/hummingbot/connector/derivative/dydx_v4_perpetual/conftest.py
+++ b/test/hummingbot/connector/derivative/dydx_v4_perpetual/conftest.py
@@ -1,6 +1,0 @@
-import importlib.util
-
-import pytest
-
-if importlib.util.find_spec("v4_proto") is None:
-    pytest.skip("v4_proto not installed", allow_module_level=True)

--- a/test/hummingbot/connector/derivative/dydx_v4_perpetual/data_sources/test_dydx_v4_data_source.py
+++ b/test/hummingbot/connector/derivative/dydx_v4_perpetual/data_sources/test_dydx_v4_data_source.py
@@ -1,13 +1,13 @@
 import asyncio
 import time
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Awaitable
 from unittest.mock import patch
 
 from hummingbot.connector.derivative.dydx_v4_perpetual import dydx_v4_perpetual_constants as CONSTANTS
 from hummingbot.connector.derivative.dydx_v4_perpetual.data_sources.dydx_v4_data_source import DydxPerpetualV4Client
 from hummingbot.connector.derivative.dydx_v4_perpetual.dydx_v4_perpetual_derivative import DydxV4PerpetualDerivative
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DydxPerpetualV4ClientTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/dydx_v4_perpetual/test_dydx_v4_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/dydx_v4_perpetual/test_dydx_v4_perpetual_api_order_book_data_source.py
@@ -4,6 +4,10 @@ import asyncio
 import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+pytest.importorskip("v4_proto")
+
 import dateutil.parser as dp
 import ujson
 from aioresponses import aioresponses

--- a/test/hummingbot/connector/derivative/dydx_v4_perpetual/test_dydx_v4_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/dydx_v4_perpetual/test_dydx_v4_perpetual_api_order_book_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import dateutil.parser as dp
@@ -19,6 +18,7 @@ from hummingbot.connector.derivative.dydx_v4_perpetual.dydx_v4_perpetual_derivat
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DydxV4PerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/dydx_v4_perpetual/test_dydx_v4_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/dydx_v4_perpetual/test_dydx_v4_perpetual_derivative.py
@@ -8,6 +8,10 @@ from functools import partial
 from typing import Any, Callable
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
+pytest.importorskip("v4_proto")
+
 from aioresponses import aioresponses
 from aioresponses.core import RequestCall
 

--- a/test/hummingbot/connector/derivative/dydx_v4_perpetual/test_dydx_v4_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/dydx_v4_perpetual/test_dydx_v4_perpetual_derivative.py
@@ -5,7 +5,6 @@ import json
 import re
 from decimal import Decimal
 from functools import partial
-from test.hummingbot.connector.derivative.dydx_v4_perpetual.programmable_v4_client import ProgrammableV4Client
 from typing import Any, Callable
 from unittest.mock import AsyncMock, patch
 
@@ -23,6 +22,7 @@ from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_row import OrderBookRow
 from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount, TradeFeeBase
+from test.hummingbot.connector.derivative.dydx_v4_perpetual.programmable_v4_client import ProgrammableV4Client
 
 
 class DydxV4PerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualDerivativeTests):

--- a/test/hummingbot/connector/derivative/dydx_v4_perpetual/test_dydx_v4_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/dydx_v4_perpetual/test_dydx_v4_perpetual_user_stream_data_source.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, patch
 
 from hummingbot.connector.derivative.dydx_v4_perpetual.dydx_v4_perpetual_derivative import DydxV4PerpetualDerivative
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DydxV4PerpetualUserStreamDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/dydx_v4_perpetual/test_dydx_v4_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/dydx_v4_perpetual/test_dydx_v4_perpetual_user_stream_data_source.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
+pytest.importorskip("v4_proto")
+
 from hummingbot.connector.derivative.dydx_v4_perpetual.dydx_v4_perpetual_derivative import DydxV4PerpetualDerivative
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase

--- a/test/hummingbot/connector/derivative/evedex_perpetual/test_evedex_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/evedex_perpetual/test_evedex_perpetual_derivative.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any, Awaitable
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,6 +21,7 @@ from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee
 from hummingbot.core.event.event_logger import EventLogger
 from hummingbot.core.event.events import MarketEvent
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class EvedexPerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/gate_io_perpetual/test_gate_io_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/gate_io_perpetual/test_gate_io_perpetual_api_order_book_data_source.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -19,6 +18,7 @@ from hummingbot.connector.test_support.network_mocking_assistant import NetworkM
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.data_type.funding_info import FundingInfo
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class GateIoPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/gate_io_perpetual/test_gate_io_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/gate_io_perpetual/test_gate_io_perpetual_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bidict import bidict
@@ -16,6 +15,7 @@ from hummingbot.connector.derivative.gate_io_perpetual.gate_io_perpetual_user_st
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestGateIoPerpetualAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_api_order_book_data_source.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -23,6 +22,7 @@ from hummingbot.connector.test_support.network_mocking_assistant import NetworkM
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.data_type.funding_info import FundingInfo, FundingInfoUpdate
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class HyperliquidPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bidict import bidict
@@ -18,6 +17,7 @@ from hummingbot.connector.derivative.hyperliquid_perpetual.hyperliquid_perpetual
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestHyperliquidPerpetualAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/injective_v2_perpetual/test_injective_v2_perpetual_derivative_for_delegated_account.py
+++ b/test/hummingbot/connector/derivative/injective_v2_perpetual/test_injective_v2_perpetual_derivative_for_delegated_account.py
@@ -6,7 +6,6 @@ import json
 from collections import OrderedDict
 from decimal import Decimal
 from functools import partial
-from test.hummingbot.connector.exchange.injective_v2.programmable_query_executor import ProgrammableQueryExecutor
 from typing import Any, Callable, Union
 from unittest.mock import AsyncMock, patch
 
@@ -49,6 +48,7 @@ from hummingbot.core.event.events import (
 )
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_gather
+from test.hummingbot.connector.exchange.injective_v2.programmable_query_executor import ProgrammableQueryExecutor
 
 
 class InjectiveV2PerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualDerivativeTests):

--- a/test/hummingbot/connector/derivative/injective_v2_perpetual/test_injective_v2_perpetual_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/injective_v2_perpetual/test_injective_v2_perpetual_order_book_data_source.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import asyncio
 import re
 from decimal import Decimal
-from test.hummingbot.connector.exchange.injective_v2.programmable_query_executor import ProgrammableQueryExecutor
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Awaitable, Union
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -30,6 +28,8 @@ from hummingbot.connector.exchange.injective_v2.injective_v2_utils import (
 from hummingbot.core.data_type.common import TradeType
 from hummingbot.core.data_type.funding_info import FundingInfo, FundingInfoUpdate
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.hummingbot.connector.exchange.injective_v2.programmable_query_executor import ProgrammableQueryExecutor
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class InjectiveV2APIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_api_order_book_data_source.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -25,6 +24,7 @@ from hummingbot.core.data_type.funding_info import FundingInfo
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
 from hummingbot.core.web_assistant.connections.connections_factory import ConnectionsFactory
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 os.environ["PYTHONASYNCIODEBUG"] = "1"
 

--- a/test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_api_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -23,6 +22,7 @@ from hummingbot.connector.derivative.kucoin_perpetual.kucoin_perpetual_derivativ
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class KucoinPerpetualAPIUserStreamDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/okx_perpetual/test_okx_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/okx_perpetual/test_okx_perpetual_api_order_book_data_source.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlencode
@@ -21,6 +20,7 @@ from hummingbot.connector.derivative.okx_perpetual.okx_perpetual_derivative impo
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.funding_info import FundingInfo, FundingInfoUpdate
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 BASE_ASSET = "COINALPHA"
 QUOTE_ASSET = "HBOT"

--- a/test/hummingbot/connector/derivative/okx_perpetual/test_okx_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/okx_perpetual/test_okx_perpetual_derivative.py
@@ -5,7 +5,6 @@ import datetime
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any, Callable
 from unittest.mock import patch
 
@@ -32,6 +31,7 @@ from hummingbot.core.event.events import (
     OrderFilledEvent,
     SellOrderCreatedEvent,
 )
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class OkxPerpetualDerivativeTests(

--- a/test/hummingbot/connector/derivative/okx_perpetual/test_okx_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/okx_perpetual/test_okx_perpetual_user_stream_data_source.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import hummingbot.connector.derivative.okx_perpetual.okx_perpetual_constants as CONSTANTS
@@ -10,6 +9,7 @@ from hummingbot.connector.derivative.okx_perpetual.okx_perpetual_user_stream_dat
     OkxPerpetualUserStreamDataSource,
 )
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class OkxPerpetualUserStreamDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/pacifica_perpetual/test_pacifica_perpetual_api_config_key.py
+++ b/test/hummingbot/connector/derivative/pacifica_perpetual/test_pacifica_perpetual_api_config_key.py
@@ -1,7 +1,8 @@
+from unittest.mock import AsyncMock
+
 from test.hummingbot.connector.derivative.pacifica_perpetual.test_pacifica_perpetual_derivative import (
     PacificaPerpetualDerivativeUnitTest,
 )
-from unittest.mock import AsyncMock
 
 
 class PacificaPerpetualAPIConfigKeyTest(PacificaPerpetualDerivativeUnitTest):

--- a/test/hummingbot/connector/derivative/pacifica_perpetual/test_pacifica_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/pacifica_perpetual/test_pacifica_perpetual_api_order_book_data_source.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -20,6 +19,7 @@ from hummingbot.core.web_assistant.connections.rest_connection import RESTConnec
 from hummingbot.core.web_assistant.connections.ws_connection import WSConnection
 from hummingbot.core.web_assistant.rest_assistant import RESTAssistant
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class PacificaPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/pacifica_perpetual/test_pacifica_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/pacifica_perpetual/test_pacifica_perpetual_derivative.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any, Callable
 
 import pandas as pd
@@ -28,6 +27,7 @@ from hummingbot.core.event.event_logger import EventLogger
 from hummingbot.core.event.events import MarketEvent
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class PacificaPerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/pacifica_perpetual/test_pacifica_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/pacifica_perpetual/test_pacifica_perpetual_user_stream_data_source.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -14,6 +13,7 @@ from hummingbot.connector.test_support.network_mocking_assistant import NetworkM
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.connections.ws_connection import WSConnection
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class PacificaPerpetualUserStreamDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/derivative/test_perpetual_budget_checker.py
+++ b/test/hummingbot/connector/derivative/test_perpetual_budget_checker.py
@@ -1,6 +1,5 @@
 import unittest
 from decimal import Decimal
-from test.mock.mock_perp_connector import MockPerpConnector
 
 from hummingbot.connector.derivative.perpetual_budget_checker import PerpetualBudgetChecker
 from hummingbot.connector.exchange.paper_trade.paper_trade_exchange import QuantizationParams
@@ -8,6 +7,7 @@ from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.order_candidate import PerpetualOrderCandidate
 from hummingbot.core.data_type.trade_fee import TradeFeeSchema
+from test.mock.mock_perp_connector import MockPerpConnector
 
 
 class PerpetualBudgetCheckerTest(unittest.TestCase):

--- a/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses import aioresponses
@@ -13,6 +12,7 @@ from hummingbot.connector.exchange.ascend_ex.ascend_ex_exchange import AscendExE
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class AscendExAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_api_user_stream_datasource.py
+++ b/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_api_user_stream_datasource.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses import aioresponses
@@ -16,6 +15,7 @@ from hummingbot.connector.exchange.ascend_ex.ascend_ex_auth import AscendExAuth
 from hummingbot.connector.exchange.ascend_ex.ascend_ex_exchange import AscendExExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class AscendExUserStreamTrackerTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/backpack/test_backpack_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/backpack/test_backpack_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses.core import aioresponses
@@ -13,6 +12,7 @@ from hummingbot.connector.exchange.backpack.backpack_exchange import BackpackExc
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BackpackAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/backpack/test_backpack_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/backpack/test_backpack_api_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bidict import bidict
@@ -14,6 +13,7 @@ from hummingbot.connector.exchange.backpack.backpack_exchange import BackpackExc
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BackpackAPIUserStreamDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/binance/test_binance_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/binance/test_binance_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses.core import aioresponses
@@ -13,6 +12,7 @@ from hummingbot.connector.exchange.binance.binance_exchange import BinanceExchan
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BinanceAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/binance/test_binance_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/binance/test_binance_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,6 +14,7 @@ from hummingbot.connector.exchange.binance.binance_exchange import BinanceExchan
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BinanceUserStreamDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/bing_x/test_bing_x_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/bing_x/test_bing_x_api_order_book_data_source.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -16,6 +15,7 @@ from hummingbot.connector.test_support.network_mocking_assistant import NetworkM
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestBingXAPIOrderBookDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/bing_x/test_bing_x_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/bing_x/test_bing_x_api_user_stream_data_source.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,6 +13,7 @@ from hummingbot.connector.exchange.bing_x.bing_x_api_user_stream_data_source imp
 from hummingbot.connector.exchange.bing_x.bing_x_auth import BingXAuth
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestBingXAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/bitget/test_bitget_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/bitget/test_bitget_api_order_book_data_source.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -19,6 +18,7 @@ from hummingbot.connector.exchange.bitget.bitget_exchange import BitgetExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BitgetAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/bitget/test_bitget_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/bitget/test_bitget_api_user_stream_data_source.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -18,6 +17,7 @@ from hummingbot.connector.exchange.bitget.bitget_exchange import BitgetExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BitgetAPIUserStreamDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/bitmart/test_bitmart_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/bitmart/test_bitmart_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -18,6 +17,7 @@ from hummingbot.connector.exchange.bitmart.bitmart_exchange import BitmartExchan
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BitmartAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/bitmart/test_bitmart_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/bitmart/test_bitmart_api_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import WSMsgType
@@ -16,6 +15,7 @@ from hummingbot.connector.exchange.bitmart.bitmart_api_user_stream_data_source i
 from hummingbot.connector.exchange.bitmart.bitmart_auth import BitmartAuth
 from hummingbot.connector.exchange.bitmart.bitmart_exchange import BitmartExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BitmartAPIUserStreamDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/bitrue/test_bitrue_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/bitrue/test_bitrue_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses.core import aioresponses
@@ -13,6 +12,7 @@ from hummingbot.connector.exchange.bitrue.bitrue_exchange import BitrueExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BitrueAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/bitrue/test_bitrue_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/bitrue/test_bitrue_user_stream_data_source.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -17,6 +16,7 @@ from hummingbot.connector.exchange.bitrue.bitrue_user_stream_data_source import 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BitrueUserStreamDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/bitstamp/test_bitstamp_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/bitstamp/test_bitstamp_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses.core import aioresponses
@@ -13,6 +12,7 @@ from hummingbot.connector.exchange.bitstamp.bitstamp_exchange import BitstampExc
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BitstampApiOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/bitstamp/test_bitstamp_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/bitstamp/test_bitstamp_api_user_stream_data_source.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses import aioresponses
@@ -13,6 +12,7 @@ from hummingbot.connector.exchange.bitstamp import bitstamp_constants as CONSTAN
 from hummingbot.connector.exchange.bitstamp.bitstamp_api_user_stream_data_source import BitstampAPIUserStreamDataSource
 from hummingbot.connector.exchange.bitstamp.bitstamp_exchange import BitstampExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BitstampUserStreamDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/btc_markets/test_btc_markets_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/btc_markets/test_btc_markets_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any, Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -20,6 +19,7 @@ from hummingbot.connector.exchange.btc_markets.btc_markets_api_order_book_data_s
 from hummingbot.connector.exchange.btc_markets.btc_markets_exchange import BtcMarketsExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BtcMarketsAPIOrderBookDataSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/btc_markets/test_btc_markets_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/btc_markets/test_btc_markets_api_user_stream_data_source.py
@@ -5,7 +5,6 @@ import base64
 import hashlib
 import hmac
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bidict import bidict
@@ -19,6 +18,7 @@ from hummingbot.connector.exchange.btc_markets.btc_markets_api_user_stream_data_
 from hummingbot.connector.exchange.btc_markets.btc_markets_auth import BtcMarketsAuth
 from hummingbot.connector.exchange.btc_markets.btc_markets_exchange import BtcMarketsExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BtcMarketsAPIUserStreamDataSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/bybit/test_bybit_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/bybit/test_bybit_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,6 +14,7 @@ from hummingbot.connector.test_support.network_mocking_assistant import NetworkM
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestBybitAPIOrderBookDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/bybit/test_bybit_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/bybit/test_bybit_api_user_stream_data_source.py
@@ -4,7 +4,6 @@ import asyncio
 import hashlib
 import hmac
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from hummingbot.connector.exchange.bybit import bybit_constants as CONSTANTS, bybit_web_utils as web_utils
@@ -12,6 +11,7 @@ from hummingbot.connector.exchange.bybit.bybit_api_user_stream_data_source impor
 from hummingbot.connector.exchange.bybit.bybit_auth import BybitAuth
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestBybitAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/coinbase_advanced_trade/test_coinbase_advanced_trade_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/coinbase_advanced_trade/test_coinbase_advanced_trade_api_order_book_data_source.py
@@ -1,8 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.logger_mixin_for_test import LoggerMixinForTest
 
 # from test.track_memory_usage import track_memory_growth
 from typing import Awaitable
@@ -27,6 +25,8 @@ from hummingbot.connector.exchange.coinbase_advanced_trade.coinbase_advanced_tra
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.logger_mixin_for_test import LoggerMixinForTest
 
 
 class CoinbaseAdvancedTradeAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):

--- a/test/hummingbot/connector/exchange/coinbase_advanced_trade/test_coinbase_advanced_trade_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/coinbase_advanced_trade/test_coinbase_advanced_trade_api_user_stream_data_source.py
@@ -5,8 +5,6 @@ import decimal
 import functools
 import unittest
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.logger_mixin_for_test import LoggerMixinForTest
 from typing import Any, AsyncGenerator, Dict
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -23,6 +21,8 @@ from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.web_assistant.connections.data_types import WSRequest, WSResponse
 from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.logger_mixin_for_test import LoggerMixinForTest
 
 
 class MockWebAssistant:

--- a/test/hummingbot/connector/exchange/coinbase_advanced_trade/test_coinbase_advanced_trade_auth.py
+++ b/test/hummingbot/connector/exchange/coinbase_advanced_trade/test_coinbase_advanced_trade_auth.py
@@ -2,7 +2,6 @@ import hashlib
 import hmac
 import logging
 from copy import copy
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -19,6 +18,7 @@ from hummingbot.connector.exchange.coinbase_advanced_trade.coinbase_advanced_tra
 )
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest, WSJSONRequest
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 # This is the algorithm used by Coinbase Advanced Trade
 private_key = ec.generate_private_key(

--- a/test/hummingbot/connector/exchange/coinbase_advanced_trade/test_coinbase_advanced_trade_exchange.py
+++ b/test/hummingbot/connector/exchange/coinbase_advanced_trade/test_coinbase_advanced_trade_exchange.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.logger_mixin_for_test import LoggerMixinForTest
 from typing import Any, Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -42,6 +41,7 @@ from hummingbot.core.event.events import (
     OrderFilledEvent,
     SellOrderCreatedEvent,
 )
+from test.logger_mixin_for_test import LoggerMixinForTest
 
 
 class CoinbaseAdvancedTradeExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests, LoggerMixinForTest):

--- a/test/hummingbot/connector/exchange/coinbase_advanced_trade/test_coinbase_advanced_trade_web_utils.py
+++ b/test/hummingbot/connector/exchange/coinbase_advanced_trade/test_coinbase_advanced_trade_web_utils.py
@@ -1,5 +1,4 @@
 import unittest
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import hummingbot.connector.exchange.coinbase_advanced_trade.coinbase_advanced_trade_constants as CONSTANTS
@@ -18,6 +17,7 @@ from hummingbot.connector.exchange.coinbase_advanced_trade.coinbase_advanced_tra
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod
 from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class CoinbaseAdvancedTradeUtilTestCases(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/cube/test_cube_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/cube/test_cube_api_order_book_data_source.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -16,6 +15,7 @@ from hummingbot.connector.test_support.network_mocking_assistant import NetworkM
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class CubeAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/cube/test_cube_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/cube/test_cube_api_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -17,6 +16,7 @@ from hummingbot.connector.test_support.network_mocking_assistant import NetworkM
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class CubeUserStreamDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/derive/test_derive_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/derive/test_derive_api_order_book_data_source.py
@@ -1,6 +1,5 @@
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,6 +13,7 @@ from hummingbot.connector.test_support.network_mocking_assistant import NetworkM
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DeriveAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/derive/test_derive_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/derive/test_derive_api_user_stream_data_source.py
@@ -4,7 +4,6 @@ import asyncio
 
 # from datetime import datetime, timezone
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bidict import bidict
@@ -16,6 +15,7 @@ from hummingbot.connector.exchange.derive.derive_exchange import DeriveExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestDeriveAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/dexalot/test_dexalot_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/dexalot/test_dexalot_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses.core import aioresponses
@@ -13,6 +12,7 @@ from hummingbot.connector.test_support.network_mocking_assistant import NetworkM
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DexalotAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/dexalot/test_dexalot_auth.py
+++ b/test/hummingbot/connector/exchange/dexalot/test_dexalot_auth.py
@@ -1,4 +1,3 @@
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import MagicMock
 
 from eth_account import Account
@@ -7,6 +6,7 @@ from eth_account.messages import encode_defunct
 from hummingbot.connector.exchange.dexalot.dexalot_auth import DexalotAuth
 from hummingbot.connector.utils import to_0x_hex
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest, WSJSONRequest
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DexalotAuthTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/dexalot/test_dexalot_exchange.py
+++ b/test/hummingbot/connector/exchange/dexalot/test_dexalot_exchange.py
@@ -5,7 +5,6 @@ import json
 import re
 from decimal import Decimal
 from functools import partial
-from test.hummingbot.connector.exchange.dexalot.programmable_client import ProgrammableClient
 from typing import Any, Callable
 from unittest.mock import AsyncMock, patch
 
@@ -23,6 +22,7 @@ from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_row import OrderBookRow
 from hummingbot.core.data_type.trade_fee import DeductedFromReturnsTradeFee, TokenAmount, TradeFeeBase
+from test.hummingbot.connector.exchange.dexalot.programmable_client import ProgrammableClient
 
 
 class DexalotExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests):

--- a/test/hummingbot/connector/exchange/dexalot/test_dexalot_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/dexalot/test_dexalot_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bidict import bidict
@@ -14,6 +13,7 @@ from hummingbot.connector.exchange.dexalot.dexalot_exchange import DexalotExchan
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestDexalotAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/foxbit/test_foxbit_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/foxbit/test_foxbit_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses.core import aioresponses
@@ -13,6 +12,7 @@ from hummingbot.connector.exchange.foxbit.foxbit_exchange import FoxbitExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class FoxbitAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/gate_io/test_gate_io_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/gate_io/test_gate_io_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict
 from unittest.mock import AsyncMock, patch
 
@@ -13,6 +12,7 @@ from hummingbot.connector.exchange.gate_io.gate_io_api_order_book_data_source im
 from hummingbot.connector.exchange.gate_io.gate_io_exchange import GateIoExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook, OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestGateIoAPIOrderBookDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/gate_io/test_gate_io_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/gate_io/test_gate_io_api_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bidict import bidict
@@ -14,6 +13,7 @@ from hummingbot.connector.exchange.gate_io.gate_io_exchange import GateIoExchang
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestGateIoAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/gate_io/test_gate_io_exchange.py
+++ b/test/hummingbot/connector/exchange/gate_io/test_gate_io_exchange.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any, Awaitable, Dict, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -32,6 +31,7 @@ from hummingbot.core.event.events import (
     OrderFilledEvent,
 )
 from hummingbot.core.network_iterator import NetworkStatus
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestGateIoExchange(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/htx/test_htx_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/htx/test_htx_api_order_book_data_source.py
@@ -2,7 +2,6 @@ import asyncio
 import gzip
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -15,6 +14,7 @@ from hummingbot.connector.exchange.htx.htx_api_order_book_data_source import Htx
 from hummingbot.connector.exchange.htx.htx_web_utils import build_api_factory
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class HtxAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/htx/test_htx_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/htx/test_htx_api_user_stream_data_source.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -9,6 +8,7 @@ from hummingbot.connector.exchange.htx.htx_api_user_stream_data_source import Ht
 from hummingbot.connector.exchange.htx.htx_auth import HtxAuth
 from hummingbot.connector.exchange.htx.htx_web_utils import build_api_factory
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class HtxAPIUserStreamDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/hyperliquid/test_hyperliquid_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/hyperliquid/test_hyperliquid_api_order_book_data_source.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -20,6 +19,7 @@ from hummingbot.connector.exchange.hyperliquid.hyperliquid_exchange import Hyper
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class HyperliquidAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/hyperliquid/test_hyperliquid_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/hyperliquid/test_hyperliquid_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bidict import bidict
@@ -16,6 +15,7 @@ from hummingbot.connector.exchange.hyperliquid.hyperliquid_exchange import Hyper
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestHyperliquidAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/injective_v2/data_sources/test_injective_data_source.py
+++ b/test/hummingbot/connector/exchange/injective_v2/data_sources/test_injective_data_source.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import re
 from decimal import Decimal
-from test.hummingbot.connector.exchange.injective_v2.programmable_query_executor import ProgrammableQueryExecutor
 from typing import Awaitable, Union
 from unittest import TestCase
 from unittest.mock import patch
@@ -27,6 +26,7 @@ from hummingbot.connector.exchange.injective_v2.injective_v2_utils import (
 )
 from hummingbot.connector.gateway.gateway_in_flight_order import GatewayInFlightOrder
 from hummingbot.core.data_type.common import OrderType, TradeType
+from test.hummingbot.connector.exchange.injective_v2.programmable_query_executor import ProgrammableQueryExecutor
 
 
 class InjectiveGranteeDataSourceTests(TestCase):

--- a/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_api_order_book_data_source.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import re
 from decimal import Decimal
-from test.hummingbot.connector.exchange.injective_v2.programmable_query_executor import ProgrammableQueryExecutor
 from typing import Awaitable, Union
 from unittest import TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -27,6 +26,7 @@ from hummingbot.connector.exchange.injective_v2.injective_v2_utils import (
 )
 from hummingbot.core.data_type.common import TradeType
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.hummingbot.connector.exchange.injective_v2.programmable_query_executor import ProgrammableQueryExecutor
 
 
 class InjectiveV2APIOrderBookDataSourceTests(TestCase):

--- a/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_exchange_for_delegated_account.py
+++ b/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_exchange_for_delegated_account.py
@@ -6,7 +6,6 @@ import json
 from collections import OrderedDict
 from decimal import Decimal
 from functools import partial
-from test.hummingbot.connector.exchange.injective_v2.programmable_query_executor import ProgrammableQueryExecutor
 from typing import Any, Callable, Union
 from unittest.mock import AsyncMock, patch
 
@@ -45,6 +44,7 @@ from hummingbot.core.event.events import (
 )
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_gather
+from test.hummingbot.connector.exchange.injective_v2.programmable_query_executor import ProgrammableQueryExecutor
 
 
 class InjectiveV2ExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests):

--- a/test/hummingbot/connector/exchange/kraken/test_kraken_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/kraken/test_kraken_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses import aioresponses
@@ -15,6 +14,7 @@ from hummingbot.connector.exchange.kraken.kraken_utils import build_rate_limits_
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.data_type.order_book import OrderBook, OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class KrakenAPIOrderBookDataSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/kraken/test_kraken_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/kraken/test_kraken_api_user_stream_data_source.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Awaitable, Dict, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -18,6 +17,7 @@ from hummingbot.connector.exchange.kraken.kraken_exchange import KrakenExchange
 from hummingbot.connector.exchange.kraken.kraken_utils import build_rate_limits_by_tier
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class KrakenAPIUserStreamDataSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/kucoin/test_kucoin_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/kucoin/test_kucoin_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -13,6 +12,7 @@ from hummingbot.connector.exchange.kucoin.kucoin_api_order_book_data_source impo
 from hummingbot.connector.exchange.kucoin.kucoin_exchange import KucoinExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestKucoinAPIOrderBookDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/kucoin/test_kucoin_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/kucoin/test_kucoin_api_user_stream_data_source.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses import aioresponses
@@ -14,6 +13,7 @@ from hummingbot.connector.exchange.kucoin.kucoin_auth import KucoinAuth
 from hummingbot.connector.exchange.kucoin.kucoin_exchange import KucoinExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestKucoinAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses.core import aioresponses
@@ -13,6 +12,7 @@ from hummingbot.connector.exchange.mexc.mexc_exchange import MexcExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class MexcAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_user_stream_data_source.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -17,6 +16,7 @@ from hummingbot.connector.exchange.mexc.mexc_exchange import MexcExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class MexcUserStreamDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Awaitable
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,6 +13,7 @@ from hummingbot.connector.exchange.ndax.ndax_exchange import NdaxExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class NdaxAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/ndax/test_ndax_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/ndax/test_ndax_api_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Awaitable
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -16,6 +15,7 @@ from hummingbot.connector.exchange.ndax.ndax_websocket_adaptor import NdaxWebSoc
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class NdaxAPIUserStreamDataSourceTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/okx/test_okx_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/okx/test_okx_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses.core import aioresponses
@@ -14,6 +13,7 @@ from hummingbot.connector.exchange.okx.okx_exchange import OkxExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class OkxAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/okx/test_okx_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/okx/test_okx_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import WSMessage, WSMsgType
@@ -11,6 +10,7 @@ from hummingbot.connector.exchange.okx.okx_api_user_stream_data_source import Ok
 from hummingbot.connector.exchange.okx.okx_auth import OkxAuth
 from hummingbot.connector.exchange.okx.okx_exchange import OkxExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class OkxUserStreamDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/vertex/conftest.py
+++ b/test/hummingbot/connector/exchange/vertex/conftest.py
@@ -1,3 +1,6 @@
+import importlib.util
+
 import pytest
 
-pytest.importorskip("eip712_structs")
+if importlib.util.find_spec("eip712_structs") is None:
+    pytest.skip("eip712_structs not installed", allow_module_level=True)

--- a/test/hummingbot/connector/exchange/vertex/conftest.py
+++ b/test/hummingbot/connector/exchange/vertex/conftest.py
@@ -1,6 +1,0 @@
-import importlib.util
-
-import pytest
-
-if importlib.util.find_spec("eip712_structs") is None:
-    pytest.skip("eip712_structs not installed", allow_module_level=True)

--- a/test/hummingbot/connector/exchange/vertex/conftest.py
+++ b/test/hummingbot/connector/exchange/vertex/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("eip712_structs")

--- a/test/hummingbot/connector/exchange/vertex/test_vertex_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/vertex/test_vertex_api_order_book_data_source.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,6 +13,7 @@ from hummingbot.connector.test_support.network_mocking_assistant import NetworkM
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 # QUEUE KEYS FOR WEBSOCKET DATA PROCESSING
 TRADE_KEY = "trade"

--- a/test/hummingbot/connector/exchange/vertex/test_vertex_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/vertex/test_vertex_api_order_book_data_source.py
@@ -3,6 +3,10 @@ import json
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+pytest.importorskip("eip712_structs")
+
 from aioresponses import aioresponses
 from bidict import bidict
 

--- a/test/hummingbot/connector/exchange/vertex/test_vertex_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/vertex/test_vertex_api_user_stream_data_source.py
@@ -5,6 +5,10 @@ import json
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+pytest.importorskip("eip712_structs")
+
 from hummingbot.connector.exchange.vertex import vertex_constants as CONSTANTS, vertex_web_utils as web_utils
 from hummingbot.connector.exchange.vertex.vertex_api_user_stream_data_source import VertexAPIUserStreamDataSource
 from hummingbot.connector.exchange.vertex.vertex_auth import VertexAuth

--- a/test/hummingbot/connector/exchange/vertex/test_vertex_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/vertex/test_vertex_api_user_stream_data_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -12,6 +11,7 @@ from hummingbot.connector.exchange.vertex.vertex_auth import VertexAuth
 from hummingbot.connector.exchange.vertex.vertex_exchange import VertexExchange
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestVertexAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/vertex/test_vertex_auth.py
+++ b/test/hummingbot/connector/exchange/vertex/test_vertex_auth.py
@@ -2,6 +2,10 @@ import asyncio
 from typing import Awaitable
 from unittest import TestCase
 
+import pytest
+
+pytest.importorskip("eip712_structs")
+
 import hummingbot.connector.exchange.vertex.vertex_constants as CONSTANTS
 from hummingbot.connector.exchange.vertex.vertex_auth import VertexAuth
 from hummingbot.connector.exchange.vertex.vertex_eip712_structs import Order

--- a/test/hummingbot/connector/exchange/vertex/test_vertex_exchange.py
+++ b/test/hummingbot/connector/exchange/vertex/test_vertex_exchange.py
@@ -8,6 +8,10 @@ from decimal import Decimal
 from typing import Any, Dict
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
+pytest.importorskip("eip712_structs")
+
 from aioresponses import aioresponses
 from bidict import bidict
 

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_amm.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_amm.py
@@ -4,7 +4,6 @@ Tests amm_get_pool_info, amm_add_liquidity, amm_remove_liquidity, amm_get_balanc
 """
 
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from xrpl.models import XRP, AMMDeposit, AMMWithdraw, IssuedCurrency, Memo, Response
@@ -18,6 +17,7 @@ from hummingbot.connector.exchange.xrpl.xrpl_utils import (
     QuoteLiquidityResponse,
     RemoveLiquidityResponse,
 )
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestXRPLAMMFunctions(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_api_order_book_data_source.py
@@ -1,6 +1,5 @@
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from xrpl.models import XRP, IssuedCurrency
@@ -13,6 +12,7 @@ from hummingbot.connector.exchange.xrpl.xrpl_worker_pool import QueryResult
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.data_type.common import TradeType
 from hummingbot.core.data_type.order_book import OrderBook
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class XRPLAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_balances.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_balances.py
@@ -7,7 +7,6 @@ Covers:
 """
 
 from decimal import Decimal
-from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 from unittest.async_case import IsolatedAsyncioTestCase
 from unittest.mock import patch
 
@@ -15,6 +14,7 @@ from xrpl.models.requests.request import RequestMethod
 
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
+from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 
 
 class TestXRPLExchangeBalances(XRPLExchangeTestBase, IsolatedAsyncioTestCase):

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_cancel_order.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_cancel_order.py
@@ -16,7 +16,6 @@ import asyncio
 import time
 import unittest
 from decimal import Decimal
-from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from xrpl.models import Response
@@ -26,6 +25,7 @@ from hummingbot.connector.exchange.xrpl import xrpl_constants as CONSTANTS
 from hummingbot.connector.exchange.xrpl.xrpl_worker_pool import TransactionSubmitResult, TransactionVerifyResult
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate
+from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 
 # --------------------------------------------------------------------------- #
 # Helpers

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_order_status.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_order_status.py
@@ -18,7 +18,6 @@ Covers:
 import asyncio
 import time
 from decimal import Decimal
-from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, patch
 
@@ -26,6 +25,7 @@ from hummingbot.connector.exchange.xrpl import xrpl_constants as CONSTANTS
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate, TradeUpdate
 from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee
+from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 
 
 class TestXRPLExchangeOrderStatus(XRPLExchangeTestBase, IsolatedAsyncioTestCase):

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_place_order.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_place_order.py
@@ -12,7 +12,6 @@ Covers:
 import time
 import unittest
 from decimal import Decimal
-from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from xrpl.models import Response
@@ -21,6 +20,7 @@ from xrpl.models.response import ResponseStatus
 from hummingbot.connector.exchange.xrpl.xrpl_worker_pool import TransactionSubmitResult
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate
+from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 
 # --------------------------------------------------------------------------- #
 # Helpers

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_pricing.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_pricing.py
@@ -16,7 +16,6 @@ Covers:
 import asyncio
 import unittest
 from decimal import Decimal
-from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from xrpl.models import Response
@@ -28,6 +27,7 @@ from hummingbot.connector.exchange.xrpl.xrpl_worker_pool import TransactionSubmi
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate
 from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee
+from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_trade_fills.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_trade_fills.py
@@ -13,13 +13,13 @@ Covers:
 import asyncio
 import unittest
 from decimal import Decimal
-from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from hummingbot.connector.exchange.xrpl.xrpl_exchange import XrplExchange
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, DeductedFromReturnsTradeFee
+from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_trading_rules.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_trading_rules.py
@@ -13,7 +13,6 @@ Covers:
 """
 
 from decimal import Decimal
-from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 from unittest.async_case import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, patch
 
@@ -22,6 +21,7 @@ from xrpl.models.requests.request import RequestMethod
 from hummingbot.connector.exchange.xrpl import xrpl_constants as CONSTANTS
 from hummingbot.connector.exchange.xrpl.xrpl_utils import PoolInfo, XRPLMarket
 from hummingbot.connector.trading_rule import TradingRule
+from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 
 
 class TestXRPLExchangeTradingRules(XRPLExchangeTestBase, IsolatedAsyncioTestCase):

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_user_stream.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_user_stream.py
@@ -9,12 +9,12 @@ Tests for:
 
 import unittest
 from decimal import Decimal
-from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
+from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_utils.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_utils.py
@@ -1,7 +1,6 @@
 import asyncio
 import time
 from collections import deque
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from xrpl.asyncio.clients import AsyncWebsocketClient, XRPLRequestFailureException
@@ -24,6 +23,7 @@ from hummingbot.connector.exchange.xrpl.xrpl_utils import (
     get_token_from_changes,
     parse_offer_create_transaction,
 )
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestXRPLUtils(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/test_markets_recorder.py
+++ b/test/hummingbot/connector/test_markets_recorder.py
@@ -1,7 +1,6 @@
 import asyncio
 import time
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Awaitable
 from unittest.mock import MagicMock, PropertyMock, patch
 
@@ -34,6 +33,7 @@ from hummingbot.strategy_v2.executors.position_executor.position_executor import
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import CloseType
 from hummingbot.strategy_v2.models.executors_info import ExecutorInfo
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class MarketsRecorderTests(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/connector/utilities/oms_connector/test_oms_connector_api_order_book_data_source.py
+++ b/test/hummingbot/connector/utilities/oms_connector/test_oms_connector_api_order_book_data_source.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -21,6 +20,7 @@ from hummingbot.connector.utilities.oms_connector.oms_connector_web_utils import
 )
 from hummingbot.core.data_type.order_book import OrderBook, OrderBookMessage
 from hummingbot.core.data_type.order_book_message import OrderBookMessageType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestURCreator(OMSConnectorURLCreatorBase):

--- a/test/hummingbot/connector/utilities/oms_connector/test_oms_connector_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/utilities/oms_connector/test_oms_connector_api_user_stream_data_source.py
@@ -4,7 +4,6 @@ import asyncio
 import hashlib
 import hmac
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -20,6 +19,7 @@ from hummingbot.connector.utilities.oms_connector.oms_connector_web_utils import
     OMSConnectorURLCreatorBase,
     build_api_factory,
 )
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestURLCreator(OMSConnectorURLCreatorBase):

--- a/test/hummingbot/connector/utilities/oms_connector/test_oms_connector_web_utils.py
+++ b/test/hummingbot/connector/utilities/oms_connector/test_oms_connector_web_utils.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, patch
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.connector.utilities.oms_connector.oms_connector_web_utils import build_api_factory
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSResponse
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class OMSConnectorWebUtilsTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/data_type/test_order_book_tracker.py
+++ b/test/hummingbot/core/data_type/test_order_book_tracker.py
@@ -13,7 +13,6 @@ import asyncio
 import time
 import unittest
 from collections import deque
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
@@ -27,6 +26,7 @@ from hummingbot.core.data_type.order_book_tracker import (
     OrderBookTrackerMetrics,
 )
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 def create_order_book_with_snapshot_uid(snapshot_uid: int) -> OrderBook:

--- a/test/hummingbot/core/data_type/test_user_stream_tracker.py
+++ b/test/hummingbot/core/data_type/test_user_stream_tracker.py
@@ -1,10 +1,10 @@
 import asyncio
 import unittest
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, patch
 
 from hummingbot.core.data_type.user_stream_tracker import UserStreamTracker
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class MockUserStreamTrackerDataSource(UserStreamTrackerDataSource):

--- a/test/hummingbot/core/data_type/test_user_stream_tracker_data_source.py
+++ b/test/hummingbot/core/data_type/test_user_stream_tracker_data_source.py
@@ -1,10 +1,10 @@
 import asyncio
 import unittest
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class MockUserStreamTrackerDataSource(UserStreamTrackerDataSource):

--- a/test/hummingbot/core/rate_oracle/sources/test_aevo_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_aevo_rate_source.py
@@ -1,9 +1,9 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import MagicMock
 
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.aevo_rate_source import AevoRateSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class AevoRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_ascend_ex_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_ascend_ex_rate_source.py
@@ -1,12 +1,12 @@
 import json
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 from aioresponses import aioresponses
 
 from hummingbot.connector.exchange.ascend_ex import ascend_ex_constants as CONSTANTS
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.ascend_ex_rate_source import AscendExRateSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class AscendExRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_binance_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_binance_rate_source.py
@@ -1,12 +1,12 @@
 import json
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 from aioresponses import aioresponses
 
 from hummingbot.connector.exchange.binance import binance_constants as CONSTANTS, binance_web_utils as web_utils
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.binance_rate_source import BinanceRateSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class BinanceRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_coin_cap_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_coin_cap_rate_source.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import re
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, patch
 
 from aioresponses import aioresponses
@@ -14,6 +13,7 @@ from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.rate_oracle.sources.coin_cap_rate_source import CoinCapRateSource
 from hummingbot.data_feed.coin_cap_data_feed import coin_cap_constants as CONSTANTS
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class CoinCapRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_coin_gecko_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_coin_gecko_rate_source.py
@@ -1,6 +1,5 @@
 import json
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, patch
 
 from aioresponses import aioresponses
@@ -9,6 +8,7 @@ from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.coin_gecko_rate_source import CoinGeckoRateSource
 from hummingbot.data_feed.coin_gecko_data_feed import coin_gecko_constants as CONSTANTS
 from hummingbot.data_feed.coin_gecko_data_feed.coin_gecko_constants import COOLOFF_AFTER_BAN, PUBLIC, CoinGeckoAPITier
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class CoinGeckoRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_coinbase_advanced_trade_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_coinbase_advanced_trade_rate_source.py
@@ -1,6 +1,5 @@
 import json
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 from aioresponses import aioresponses
 
@@ -10,6 +9,7 @@ from hummingbot.connector.exchange.coinbase_advanced_trade import (
 )
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.coinbase_advanced_trade_rate_source import CoinbaseAdvancedTradeRateSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class CoinbaseAdvancedTradeRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_cube_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_cube_rate_source.py
@@ -1,11 +1,11 @@
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 from aioresponses import aioresponses
 
 from hummingbot.connector.exchange.cube import cube_constants as CONSTANTS, cube_web_utils as web_utils
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.cube_rate_source import CubeRateSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class CubeRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_decibel_perpetual_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_decibel_perpetual_rate_source.py
@@ -1,11 +1,11 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.decibel_perpetual_rate_source import DecibelPerpetualRateSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DecibelPerpetualRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_dexalot_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_dexalot_rate_source.py
@@ -1,6 +1,5 @@
 import json
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, patch
 
 from aioresponses import aioresponses
@@ -10,6 +9,7 @@ from hummingbot.connector.test_support.network_mocking_assistant import NetworkM
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.dexalot_rate_source import DexalotRateSource
 from hummingbot.core.web_assistant.connections.connections_factory import ConnectionsFactory
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DexalotRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_evedex_perpetual_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_evedex_perpetual_rate_source.py
@@ -1,9 +1,9 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import MagicMock
 
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.evedex_perpetual_rate_source import EvedexPerpetualRateSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class EvedexPerpetualRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_gate_io_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_gate_io_rate_source.py
@@ -1,12 +1,12 @@
 import json
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 from aioresponses import aioresponses
 
 from hummingbot.connector.exchange.gate_io import gate_io_constants as CONSTANTS
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.gate_io_rate_source import GateIoRateSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class GateIoRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_hyperliquid_perpetual_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_hyperliquid_perpetual_rate_source.py
@@ -1,11 +1,11 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import MagicMock
 
 import pytest
 
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.hyperliquid_perpetual_rate_source import HyperliquidPerpetualRateSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class HyperliquidPerpetualRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_hyperliquid_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_hyperliquid_rate_source.py
@@ -1,6 +1,5 @@
 import json
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 from aioresponses import aioresponses
 
@@ -10,6 +9,7 @@ from hummingbot.connector.exchange.hyperliquid import (
 )
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.hyperliquid_rate_source import HyperliquidRateSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class HyperliquidRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_kucoin_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_kucoin_rate_source.py
@@ -1,12 +1,12 @@
 import json
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 from aioresponses import aioresponses
 
 from hummingbot.connector.exchange.kucoin import kucoin_constants as CONSTANTS
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.kucoin_rate_source import KucoinRateSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class KucoinRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_mexc_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_mexc_rate_source.py
@@ -1,12 +1,12 @@
 import json
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 from aioresponses import aioresponses
 
 from hummingbot.connector.exchange.mexc import mexc_constants as CONSTANTS, mexc_web_utils as web_utils
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.mexc_rate_source import MexcRateSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class MexcRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/sources/test_pacifica_perpetual_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_pacifica_perpetual_rate_source.py
@@ -1,11 +1,11 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import MagicMock
 
 import pytest
 
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.rate_oracle.sources.pacifica_perpetual_rate_source import PacificaPerpetualRateSource
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class PacificaPerpetualRateSourceTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/rate_oracle/test_rate_oracle.py
+++ b/test/hummingbot/core/rate_oracle/test_rate_oracle.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from copy import deepcopy
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import MagicMock
 
 from hummingbot.client.config.client_config_map import ClientConfigMap
@@ -13,6 +12,7 @@ from hummingbot.core.rate_oracle.rate_oracle import RateOracle
 from hummingbot.core.rate_oracle.sources.coin_gecko_rate_source import CoinGeckoRateSource
 from hummingbot.core.rate_oracle.sources.rate_source_base import RateSourceBase
 from hummingbot.core.rate_oracle.utils import find_rate
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DummyRateSource(RateSourceBase):

--- a/test/hummingbot/core/test_connector_manager.py
+++ b/test/hummingbot/core/test_connector_manager.py
@@ -1,11 +1,11 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from hummingbot.client.config.client_config_map import ClientConfigMap
 from hummingbot.client.config.config_helpers import ClientConfigAdapter
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.core.connector_manager import ConnectorManager
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class ConnectorManagerTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/test_network_base.py
+++ b/test/hummingbot/core/test_network_base.py
@@ -1,9 +1,9 @@
 import asyncio
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import patch
 
 from hummingbot.core.network_base import NetworkBase
 from hummingbot.core.network_iterator import NetworkStatus
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class SampleNetwork(NetworkBase):

--- a/test/hummingbot/core/test_network_iterator.py
+++ b/test/hummingbot/core/test_network_iterator.py
@@ -1,10 +1,10 @@
 import asyncio
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 import pandas as pd
 
 from hummingbot.core.clock import Clock, ClockMode
 from hummingbot.core.network_iterator import NetworkIterator, NetworkStatus
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class MockNetworkIterator(NetworkIterator):

--- a/test/hummingbot/core/test_pubsub.py
+++ b/test/hummingbot/core/test_pubsub.py
@@ -1,10 +1,10 @@
 import gc
 import unittest
 import weakref
-from test.mock.mock_events import MockEvent, MockEventType
 
 from hummingbot.core.event.event_logger import EventLogger
 from hummingbot.core.pubsub import PubSub
+from test.mock.mock_events import MockEvent, MockEventType
 
 
 class PubSubTest(unittest.TestCase):

--- a/test/hummingbot/core/test_trading_core.py
+++ b/test/hummingbot/core/test_trading_core.py
@@ -2,7 +2,6 @@ import asyncio
 import time
 from decimal import Decimal
 from pathlib import Path
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, Mock, patch
 
 from pydantic import Field
@@ -19,6 +18,7 @@ from hummingbot.exceptions import InvalidScriptModule
 from hummingbot.model.trade_fill import TradeFill
 from hummingbot.strategy.strategy_base import StrategyBase
 from hummingbot.strategy.strategy_v2_base import StrategyV2Base, StrategyV2ConfigBase
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class MockStrategy(StrategyBase):

--- a/test/hummingbot/core/web_assistant/connections/test_connections_factory.py
+++ b/test/hummingbot/core/web_assistant/connections/test_connections_factory.py
@@ -1,8 +1,7 @@
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-
 from hummingbot.core.web_assistant.connections.connections_factory import ConnectionsFactory
 from hummingbot.core.web_assistant.connections.rest_connection import RESTConnection
 from hummingbot.core.web_assistant.connections.ws_connection import WSConnection
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class ConnectionsFactoryTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/web_assistant/connections/test_data_types.py
+++ b/test/hummingbot/core/web_assistant/connections/test_data_types.py
@@ -1,11 +1,11 @@
 import json
 import unittest
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 import aiohttp
 from aioresponses import aioresponses
 
 from hummingbot.core.web_assistant.connections.data_types import EndpointRESTRequest, RESTMethod, RESTResponse
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class DataTypesTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/web_assistant/connections/test_rest_connection.py
+++ b/test/hummingbot/core/web_assistant/connections/test_rest_connection.py
@@ -1,12 +1,12 @@
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 import aiohttp
 from aioresponses import aioresponses
 
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest, RESTResponse
 from hummingbot.core.web_assistant.connections.rest_connection import RESTConnection
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class RESTConnectionTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/web_assistant/connections/test_ws_connection.py
+++ b/test/hummingbot/core/web_assistant/connections/test_ws_connection.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, patch
 
 import aiohttp
@@ -9,6 +8,7 @@ from aiohttp import WebSocketError
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSResponse
 from hummingbot.core.web_assistant.connections.ws_connection import WSConnection
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class WSConnectionTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/web_assistant/test_rest_assistant.py
+++ b/test/hummingbot/core/web_assistant/test_rest_assistant.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import patch
 
 import aiohttp
@@ -14,6 +13,7 @@ from hummingbot.core.web_assistant.connections.rest_connection import RESTConnec
 from hummingbot.core.web_assistant.rest_assistant import RESTAssistant
 from hummingbot.core.web_assistant.rest_post_processors import RESTPostProcessorBase
 from hummingbot.core.web_assistant.rest_pre_processors import RESTPreProcessorBase
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class RESTAssistantTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/core/web_assistant/test_ws_assistant.py
+++ b/test/hummingbot/core/web_assistant/test_ws_assistant.py
@@ -1,4 +1,3 @@
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 import aiohttp
@@ -11,6 +10,7 @@ from hummingbot.core.web_assistant.connections.ws_connection import WSConnection
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.core.web_assistant.ws_post_processors import WSPostProcessorBase
 from hummingbot.core.web_assistant.ws_pre_processors import WSPreProcessorBase
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class WSAssistantTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/data_feed/candles_feed/aevo_perpetual_candles/test_aevo_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/aevo_perpetual_candles/test_aevo_perpetual_candles.py
@@ -1,9 +1,9 @@
 import re
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from aioresponses import aioresponses
 
 from hummingbot.data_feed.candles_feed.aevo_perpetual_candles import AevoPerpetualCandles, constants as CONSTANTS
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestAevoPerpetualCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/ascend_ex_spot_candles/test_ascend_ex_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/ascend_ex_spot_candles/test_ascend_ex_spot_candles.py
@@ -1,8 +1,7 @@
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
-
 import hummingbot.data_feed.candles_feed.okx_spot_candles.constants as CONSTANTS
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.ascend_ex_spot_candles import AscendExSpotCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestAscendExSpotCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/binance_perpetual_candles/test_binance_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/binance_perpetual_candles/test_binance_perpetual_candles.py
@@ -1,8 +1,8 @@
 import asyncio
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.binance_perpetual_candles import BinancePerpetualCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestBinancePerpetualCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/binance_spot_candles/test_binance_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/binance_spot_candles/test_binance_spot_candles.py
@@ -1,8 +1,8 @@
 import asyncio
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.binance_spot_candles import BinanceSpotCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestBinanceSpotCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/bitget_perpetual_candles/test_bitget_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/bitget_perpetual_candles/test_bitget_perpetual_candles.py
@@ -1,8 +1,8 @@
 import asyncio
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.bitget_perpetual_candles import BitgetPerpetualCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestBitgetPerpetualCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/bitget_spot_candles/test_bitget_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/bitget_spot_candles/test_bitget_spot_candles.py
@@ -1,8 +1,8 @@
 import asyncio
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.bitget_spot_candles import BitgetSpotCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestBitgetSpotCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/bitmart_perpetual_candles/test_bitmart_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/bitmart_perpetual_candles/test_bitmart_perpetual_candles.py
@@ -1,8 +1,8 @@
 import asyncio
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.bitmart_perpetual_candles import BitmartPerpetualCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestBitmartPerpetualCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/btc_markets_spot_candles/test_btc_markets_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/btc_markets_spot_candles/test_btc_markets_spot_candles.py
@@ -1,12 +1,12 @@
 import asyncio
 import warnings
 from datetime import datetime, timezone
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.data_feed.candles_feed.btc_markets_spot_candles.btc_markets_spot_candles import BtcMarketsSpotCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestBtcMarketsSpotCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/bybit_perpetual_candles/test_bybit_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/bybit_perpetual_candles/test_bybit_perpetual_candles.py
@@ -1,8 +1,8 @@
 import asyncio
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.bybit_perpetual_candles import BybitPerpetualCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestBybitPerpetualCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/bybit_spot_candles/test_bybit_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/bybit_spot_candles/test_bybit_spot_candles.py
@@ -1,8 +1,8 @@
 import asyncio
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.bybit_spot_candles import BybitSpotCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestBybitSpotCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/decibel_perpetual_candles/test_decibel_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/decibel_perpetual_candles/test_decibel_perpetual_candles.py
@@ -1,8 +1,8 @@
 import asyncio
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.decibel_perpetual_candles import DecibelPerpetualCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestDecibelPerpetualCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/dexalot_spot_candles/test_dexalot_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/dexalot_spot_candles/test_dexalot_spot_candles.py
@@ -1,8 +1,8 @@
 import asyncio
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.dexalot_spot_candles import DexalotSpotCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestDexalotSpotCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/evedex_perpetual_candles/test_evedex_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/evedex_perpetual_candles/test_evedex_perpetual_candles.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import re
 from datetime import datetime, timezone
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses import aioresponses
@@ -11,6 +10,7 @@ from hummingbot.connector.test_support.network_mocking_assistant import NetworkM
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
 from hummingbot.data_feed.candles_feed.evedex_perpetual_candles import EvedexPerpetualCandles, constants as CONSTANTS
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestEvedexPerpetualCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/gate_io_perpetual_candles/test_gate_io_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/gate_io_perpetual_candles/test_gate_io_perpetual_candles.py
@@ -1,8 +1,8 @@
 import asyncio
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.gate_io_perpetual_candles import GateioPerpetualCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestGateioPerpetualCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/gate_io_spot_candles/test_gate_io_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/gate_io_spot_candles/test_gate_io_spot_candles.py
@@ -2,13 +2,13 @@ import asyncio
 import json
 import re
 import time
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from aioresponses import aioresponses
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.data_types import HistoricalCandlesConfig
 from hummingbot.data_feed.candles_feed.gate_io_spot_candles import GateioSpotCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestGateioSpotCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/grvt_perpetual_candles/test_grvt_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/grvt_perpetual_candles/test_grvt_perpetual_candles.py
@@ -1,12 +1,12 @@
 import asyncio
 import json
 import re
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from aioresponses import aioresponses
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.grvt_perpetual_candles import GrvtPerpetualCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestGrvtPerpetualCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/hyperliquid_perpetual_candles/test_hyperliquid_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/hyperliquid_perpetual_candles/test_hyperliquid_perpetual_candles.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from aioresponses import aioresponses
 
@@ -10,6 +9,7 @@ from hummingbot.data_feed.candles_feed.hyperliquid_perpetual_candles import (
     HyperliquidPerpetualCandles,
     constants as CONSTANTS,
 )
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestHyperliquidPerpetualCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/hyperliquid_spot_candles/test_hyperliquid_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/hyperliquid_spot_candles/test_hyperliquid_spot_candles.py
@@ -1,12 +1,12 @@
 import asyncio
 import json
 import re
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from aioresponses import aioresponses
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.hyperliquid_spot_candles import HyperliquidSpotCandles, constants as CONSTANTS
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestHyperliquidSpotC0andles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/kraken_spot_candles/test_kraken_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/kraken_spot_candles/test_kraken_spot_candles.py
@@ -2,13 +2,13 @@ import asyncio
 import json
 import re
 import time
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from aioresponses import aioresponses
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.data_types import HistoricalCandlesConfig
 from hummingbot.data_feed.candles_feed.kraken_spot_candles import KrakenSpotCandles, constants as CONSTANTS
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestKrakenSpotCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/kucoin_perpetual_candles/test_kucoin_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/kucoin_perpetual_candles/test_kucoin_perpetual_candles.py
@@ -1,13 +1,13 @@
 import asyncio
 import json
 import re
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from aioresponses import aioresponses
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 from hummingbot.data_feed.candles_feed.kucoin_perpetual_candles import KucoinPerpetualCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestKucoinPerpetualCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/kucoin_spot_candles/test_kucoin_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/kucoin_spot_candles/test_kucoin_spot_candles.py
@@ -1,9 +1,9 @@
 import asyncio
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 from hummingbot.data_feed.candles_feed.kucoin_spot_candles import KucoinSpotCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestKucoinSpotCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/lighter_perpetual_candles/test_lighter_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/lighter_perpetual_candles/test_lighter_perpetual_candles.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 from unittest.mock import AsyncMock, patch
 
 import numpy as np
@@ -10,6 +9,7 @@ from aioresponses import aioresponses
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.data_feed.candles_feed.lighter_perpetual_candles import LighterPerpetualCandles, constants as CONSTANTS
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 PATCH_FETCH = "hummingbot.data_feed.candles_feed.lighter_perpetual_candles.lighter_perpetual_candles.LighterPerpetualCandles.fetch_candles"
 PATCH_SLEEP = "hummingbot.data_feed.candles_feed.lighter_perpetual_candles.lighter_perpetual_candles.LighterPerpetualCandles._sleep"

--- a/test/hummingbot/data_feed/candles_feed/lighter_spot_candles/test_lighter_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/lighter_spot_candles/test_lighter_spot_candles.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 from unittest.mock import AsyncMock, patch
 
 import numpy as np
@@ -10,6 +9,7 @@ from aioresponses import aioresponses
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.data_feed.candles_feed.lighter_spot_candles import LighterSpotCandles, constants as CONSTANTS
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 PATCH_FETCH = (
     "hummingbot.data_feed.candles_feed.lighter_spot_candles.lighter_spot_candles.LighterSpotCandles.fetch_candles"

--- a/test/hummingbot/data_feed/candles_feed/mexc_perpetual_candles/test_mexc_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/mexc_perpetual_candles/test_mexc_perpetual_candles.py
@@ -1,8 +1,8 @@
 import asyncio
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.mexc_perpetual_candles import MexcPerpetualCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestMexcPerpetualCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/mexc_spot_candles/test_mexc_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/mexc_spot_candles/test_mexc_spot_candles.py
@@ -1,8 +1,8 @@
 import asyncio
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.mexc_spot_candles import MexcSpotCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestMexcSpotCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/okx_perpetual_candles/test_okx_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/okx_perpetual_candles/test_okx_perpetual_candles.py
@@ -1,7 +1,6 @@
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
-
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.okx_perpetual_candles import OKXPerpetualCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestOKXPerpetualCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/okx_spot_candles/test_okx_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/okx_spot_candles/test_okx_spot_candles.py
@@ -1,7 +1,6 @@
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
-
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.okx_spot_candles import OKXSpotCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestOKXSpotCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/pacifica_perpetual_candles/test_pacifica_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/pacifica_perpetual_candles/test_pacifica_perpetual_candles.py
@@ -1,8 +1,8 @@
 import asyncio
-from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.pacifica_perpetual_candles import PacificaPerpetualCandles
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
 
 
 class TestPacificaPerpetualCandles(TestCandlesBase):

--- a/test/hummingbot/data_feed/candles_feed/test_candles_base.py
+++ b/test/hummingbot/data_feed/candles_feed/test_candles_base.py
@@ -7,7 +7,6 @@ import re
 import time
 from abc import ABC
 from collections import deque
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
@@ -16,6 +15,7 @@ from aioresponses import aioresponses
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.candles_base import CandlesBase
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestCandlesBase(IsolatedAsyncioWrapperTestCase, ABC):

--- a/test/hummingbot/data_feed/liquidations_feed/binance/test_binance_liquidations.py
+++ b/test/hummingbot/data_feed/liquidations_feed/binance/test_binance_liquidations.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioresponses import aioresponses
@@ -9,6 +8,7 @@ from bidict import bidict
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.liquidations_feed.binance import BinancePerpetualLiquidations, constants as CONSTANTS
 from hummingbot.data_feed.liquidations_feed.liquidations_base import LiquidationSide
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestBinanceLiquidations(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/data_feed/test_amm_gateway_data_feed.py
+++ b/test/hummingbot/data_feed/test_amm_gateway_data_feed.py
@@ -1,11 +1,11 @@
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.logger_mixin_for_test import LoggerMixinForTest, LogLevel
 from unittest.mock import AsyncMock, patch
 
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.data_feed.amm_gateway_data_feed import AmmGatewayDataFeed
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.logger_mixin_for_test import LoggerMixinForTest, LogLevel
 
 
 class TestAmmGatewayDataFeed(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):

--- a/test/hummingbot/data_feed/test_market_data_provider.py
+++ b/test/hummingbot/data_feed/test_market_data_provider.py
@@ -1,6 +1,5 @@
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pandas as pd
@@ -13,6 +12,7 @@ from hummingbot.data_feed.candles_feed.candles_base import CandlesBase
 from hummingbot.data_feed.candles_feed.data_types import CandlesConfig
 from hummingbot.strategy.strategy_v2_base import MarketDataProvider
 from hummingbot.strategy_v2.executors.data_types import ConnectorPair
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestMarketDataProvider(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/data_feed/test_wallet_tracker_data_feed.py
+++ b/test/hummingbot/data_feed/test_wallet_tracker_data_feed.py
@@ -1,11 +1,11 @@
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.logger_mixin_for_test import LoggerMixinForTest, LogLevel
 from unittest.mock import AsyncMock, patch
 
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.data_feed.wallet_tracker_data_feed import WalletTrackerDataFeed
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.logger_mixin_for_test import LoggerMixinForTest, LogLevel
 
 
 class TestWalletTrackerDataFeed(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):

--- a/test/hummingbot/notifier/test_notifier_base.py
+++ b/test/hummingbot/notifier/test_notifier_base.py
@@ -1,8 +1,8 @@
 import asyncio
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, patch
 
 from hummingbot.notifier.notifier_base import NotifierBase
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestNotifierBase(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/strategy/amm_arb/test_amm_arb_start.py
+++ b/test/hummingbot/strategy/amm_arb/test_amm_arb_start.py
@@ -1,11 +1,11 @@
 import unittest.mock
 from decimal import Decimal
-from test.hummingbot.strategy import assign_config_default
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 import hummingbot.strategy.amm_arb.start as amm_arb_start
 from hummingbot.strategy.amm_arb.amm_arb import AmmArbStrategy
 from hummingbot.strategy.amm_arb.amm_arb_config_map import amm_arb_config_map
+from test.hummingbot.strategy import assign_config_default
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class AMMArbStartTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making_start.py
+++ b/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making_start.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 import unittest.mock
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 import hummingbot.strategy.avellaneda_market_making.start as strategy_start
 from hummingbot.client.config.config_helpers import ClientConfigAdapter
@@ -14,6 +13,7 @@ from hummingbot.strategy.avellaneda_market_making.avellaneda_market_making_confi
     MultiOrderLevelModel,
     TrackHangingOrdersModel,
 )
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class AvellanedaStartTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/strategy/cross_exchange_market_making/test_cross_exchange_market_making_start.py
+++ b/test/hummingbot/strategy/cross_exchange_market_making/test_cross_exchange_market_making_start.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 import hummingbot.strategy.cross_exchange_market_making.start as strategy_start
 from hummingbot.client.config.client_config_map import ClientConfigMap
@@ -9,6 +8,7 @@ from hummingbot.strategy.cross_exchange_market_making.cross_exchange_market_maki
     CrossExchangeMarketMakingConfigMap,
     TakerToMakerConversionRateMode,
 )
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class XEMMStartTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/strategy/hedge/test_hedge.py
+++ b/test/hummingbot/strategy/hedge/test_hedge.py
@@ -1,6 +1,5 @@
 import unittest
 from decimal import Decimal
-from test.mock.mock_perp_connector import MockPerpConnector
 
 import pandas as pd
 
@@ -14,6 +13,7 @@ from hummingbot.core.data_type.common import PositionMode, PositionSide
 from hummingbot.strategy.hedge.hedge import HedgeStrategy
 from hummingbot.strategy.hedge.hedge_config_map_pydantic import HedgeConfigMap
 from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
+from test.mock.mock_perp_connector import MockPerpConnector
 
 
 class HedgeConfigMapPydanticTest(unittest.TestCase):

--- a/test/hummingbot/strategy/liquidity_mining/test_liquidity_mining_config_map.py
+++ b/test/hummingbot/strategy/liquidity_mining/test_liquidity_mining_config_map.py
@@ -1,10 +1,10 @@
-from test.hummingbot.strategy import assign_config_default
 from unittest import TestCase
 
 import hummingbot.strategy.liquidity_mining.liquidity_mining_config_map as liquidity_mining_config_map_module
 from hummingbot.strategy.liquidity_mining.liquidity_mining_config_map import (
     liquidity_mining_config_map as strategy_cmap,
 )
+from test.hummingbot.strategy import assign_config_default
 
 
 class LiquidityMiningConfigMapTests(TestCase):

--- a/test/hummingbot/strategy/liquidity_mining/test_liquidity_mining_start.py
+++ b/test/hummingbot/strategy/liquidity_mining/test_liquidity_mining_start.py
@@ -1,6 +1,4 @@
 from decimal import Decimal
-from test.hummingbot.strategy import assign_config_default
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 import hummingbot.strategy.liquidity_mining.start as strategy_start
 from hummingbot.client.config.client_config_map import ClientConfigMap
@@ -8,6 +6,8 @@ from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.strategy.liquidity_mining.liquidity_mining_config_map import (
     liquidity_mining_config_map as strategy_cmap,
 )
+from test.hummingbot.strategy import assign_config_default
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class LiquidityMiningStartTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/strategy/perpetual_market_making/test_perpetual_market_making.py
+++ b/test/hummingbot/strategy/perpetual_market_making/test_perpetual_market_making.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from test.mock.mock_perp_connector import MockPerpConnector
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -25,6 +24,7 @@ from hummingbot.strategy.data_types import PriceSize, Proposal
 from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 from hummingbot.strategy.perpetual_market_making import PerpetualMarketMakingStrategy
 from hummingbot.strategy.strategy_base import StrategyBase
+from test.mock.mock_perp_connector import MockPerpConnector
 
 
 class PerpetualMarketMakingTests(TestCase):

--- a/test/hummingbot/strategy/perpetual_market_making/test_perpetual_market_making_start.py
+++ b/test/hummingbot/strategy/perpetual_market_making/test_perpetual_market_making_start.py
@@ -1,12 +1,12 @@
 from decimal import Decimal
-from test.hummingbot.strategy import assign_config_default
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 import hummingbot.strategy.perpetual_market_making.start as strategy_start
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.strategy.perpetual_market_making.perpetual_market_making_config_map import (
     perpetual_market_making_config_map as c_map,
 )
+from test.hummingbot.strategy import assign_config_default
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class PerpetualMarketMakingStartTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/strategy/pure_market_making/test_pmm.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import unittest
 from decimal import Decimal
-from test.mock.mock_asset_price_delegate import MockAssetPriceDelegate
 
 import pandas as pd
 
@@ -23,6 +22,7 @@ from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 from hummingbot.strategy.order_book_asset_price_delegate import OrderBookAssetPriceDelegate
 from hummingbot.strategy.pure_market_making.inventory_cost_price_delegate import InventoryCostPriceDelegate
 from hummingbot.strategy.pure_market_making.pure_market_making import PureMarketMakingStrategy
+from test.mock.mock_asset_price_delegate import MockAssetPriceDelegate
 
 
 # Update the orderbook so that the top bids and asks are lower than actual for a wider bid ask spread

--- a/test/hummingbot/strategy/pure_market_making/test_pure_market_making_start.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pure_market_making_start.py
@@ -1,7 +1,5 @@
 import unittest.mock
 from decimal import Decimal
-from test.hummingbot.strategy import assign_config_default
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 import hummingbot.strategy.pure_market_making.start as strategy_start
 from hummingbot.client.config.client_config_map import ClientConfigMap
@@ -9,6 +7,8 @@ from hummingbot.client.config.config_helpers import ClientConfigAdapter
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.core.data_type.common import PriceType
 from hummingbot.strategy.pure_market_making.pure_market_making_config_map import pure_market_making_config_map as c_map
+from test.hummingbot.strategy import assign_config_default
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class PureMarketMakingStartTest(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/strategy/spot_perpetual_arbitrage/test_spot_perpetual_arbitrage.py
+++ b/test/hummingbot/strategy/spot_perpetual_arbitrage/test_spot_perpetual_arbitrage.py
@@ -1,7 +1,6 @@
 import asyncio
 import unittest
 from decimal import Decimal
-from test.mock.mock_perp_connector import MockPerpConnector
 from unittest.mock import patch
 
 import pandas as pd
@@ -25,6 +24,7 @@ from hummingbot.strategy.spot_perpetual_arbitrage.spot_perpetual_arbitrage impor
     SpotPerpetualArbitrageStrategy,
     StrategyState,
 )
+from test.mock.mock_perp_connector import MockPerpConnector
 
 trading_pair = "HBOT-USDT"
 base_asset = trading_pair.split("-")[0]

--- a/test/hummingbot/strategy/spot_perpetual_arbitrage/test_spot_perpetual_arbitrage_start.py
+++ b/test/hummingbot/strategy/spot_perpetual_arbitrage/test_spot_perpetual_arbitrage_start.py
@@ -1,7 +1,5 @@
 import unittest.mock
 from decimal import Decimal
-from test.hummingbot.strategy import assign_config_default
-from test.mock.mock_perp_connector import MockPerpConnector
 
 import hummingbot.strategy.spot_perpetual_arbitrage.start as strategy_start
 from hummingbot.client.config.client_config_map import ClientConfigMap
@@ -10,6 +8,8 @@ from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.strategy.spot_perpetual_arbitrage.spot_perpetual_arbitrage_config_map import (
     spot_perpetual_arbitrage_config_map as strategy_cmap,
 )
+from test.hummingbot.strategy import assign_config_default
+from test.mock.mock_perp_connector import MockPerpConnector
 
 
 class SpotPerpetualArbitrageStartTest(unittest.TestCase):

--- a/test/hummingbot/strategy/test_strategy_v2_base.py
+++ b/test/hummingbot/strategy/test_strategy_v2_base.py
@@ -1,7 +1,6 @@
 import asyncio
 import unittest
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pandas as pd
@@ -19,6 +18,7 @@ from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction
 from hummingbot.strategy_v2.models.executors import CloseType
 from hummingbot.strategy_v2.models.executors_info import ExecutorInfo, PerformanceReport
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class MockScriptStrategy(StrategyV2Base):

--- a/test/hummingbot/strategy_v2/controllers/test_controller_base.py
+++ b/test/hummingbot/strategy_v2/controllers/test_controller_base.py
@@ -1,6 +1,5 @@
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 from hummingbot.core.data_type.common import PriceType, TradeType
@@ -11,6 +10,7 @@ from hummingbot.strategy_v2.executors.position_executor.data_types import Triple
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import CloseType
 from hummingbot.strategy_v2.models.executors_info import ExecutorInfo
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestControllerBase(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/strategy_v2/controllers/test_directional_trading_controller_base.py
+++ b/test/hummingbot/strategy_v2/controllers/test_directional_trading_controller_base.py
@@ -1,6 +1,5 @@
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from hummingbot.core.data_type.common import MarketDict, OrderType, PositionMode, TradeType
@@ -11,6 +10,7 @@ from hummingbot.strategy_v2.controllers.directional_trading_controller_base impo
 )
 from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig, TrailingStop
 from hummingbot.strategy_v2.models.executor_actions import ExecutorAction
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestDirectionalTradingControllerBase(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/strategy_v2/controllers/test_market_making_controller_base.py
+++ b/test/hummingbot/strategy_v2/controllers/test_market_making_controller_base.py
@@ -1,6 +1,5 @@
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from hummingbot.core.data_type.common import MarketDict, OrderType, PositionMode, TradeType
@@ -14,6 +13,7 @@ from hummingbot.strategy_v2.executors.order_executor.data_types import Execution
 from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig, TrailingStop
 from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, ExecutorAction, StopExecutorAction
 from hummingbot.strategy_v2.models.executors_info import ExecutorInfo
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestMarketMakingControllerBase(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/strategy_v2/controllers/test_progressive_trading_controller_base.py
+++ b/test/hummingbot/strategy_v2/controllers/test_progressive_trading_controller_base.py
@@ -1,6 +1,5 @@
 import asyncio
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from hummingbot.core.data_type.common import MarketDict, OrderType, PositionMode, TradeType
@@ -15,6 +14,7 @@ from hummingbot.strategy_v2.executors.progressive_executor.data_types import (
     YieldTripleBarrierConfig,
 )
 from hummingbot.strategy_v2.models.executor_actions import ExecutorAction
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestProgressiveTradingControllerBase(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/strategy_v2/executors/arbitrage_executor/test_arbitrage_executor.py
+++ b/test/hummingbot/strategy_v2/executors/arbitrage_executor/test_arbitrage_executor.py
@@ -1,6 +1,4 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.logger_mixin_for_test import LoggerMixinForTest
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 from hummingbot.connector.connector_base import ConnectorBase
@@ -12,6 +10,8 @@ from hummingbot.strategy_v2.executors.arbitrage_executor.data_types import Arbit
 from hummingbot.strategy_v2.executors.data_types import ConnectorPair
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import CloseType, TrackedOrder
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.logger_mixin_for_test import LoggerMixinForTest
 
 
 class TestArbitrageExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):

--- a/test/hummingbot/strategy_v2/executors/dca_executor/test_dca_executor.py
+++ b/test/hummingbot/strategy_v2/executors/dca_executor/test_dca_executor.py
@@ -1,6 +1,4 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.logger_mixin_for_test import LoggerMixinForTest
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from hummingbot.connector.exchange_py_base import ExchangePyBase
@@ -15,6 +13,8 @@ from hummingbot.strategy_v2.executors.dca_executor.dca_executor import DCAExecut
 from hummingbot.strategy_v2.executors.position_executor.data_types import TrailingStop
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import TrackedOrder
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.logger_mixin_for_test import LoggerMixinForTest
 
 
 class TestDCAExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):

--- a/test/hummingbot/strategy_v2/executors/executor_integration_test_base.py
+++ b/test/hummingbot/strategy_v2/executors/executor_integration_test_base.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import time
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.logger_mixin_for_test import LoggerMixinForTest
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pandas as pd
@@ -27,6 +25,8 @@ from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 from hummingbot.strategy.strategy_v2_base import StrategyV2Base, StrategyV2ConfigBase
 from hummingbot.strategy_v2.executors.data_types import ExecutorConfigBase
 from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, ExecutorAction
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.logger_mixin_for_test import LoggerMixinForTest
 
 
 class ExtendedMockPaperExchange(MockPaperExchange):

--- a/test/hummingbot/strategy_v2/executors/grid_executor/test_grid_executor.py
+++ b/test/hummingbot/strategy_v2/executors/grid_executor/test_grid_executor.py
@@ -1,6 +1,4 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.logger_mixin_for_test import LoggerMixinForTest
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from hummingbot.connector.exchange_py_base import ExchangePyBase
@@ -22,6 +20,8 @@ from hummingbot.strategy_v2.executors.grid_executor.grid_executor import GridExe
 from hummingbot.strategy_v2.executors.position_executor.data_types import TrailingStop, TripleBarrierConfig
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import CloseType, TrackedOrder
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.logger_mixin_for_test import LoggerMixinForTest
 
 
 class TestGridExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):

--- a/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
+++ b/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
@@ -1,6 +1,4 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.logger_mixin_for_test import LoggerMixinForTest
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from hummingbot.core.data_type.common import TradeType
@@ -11,6 +9,8 @@ from hummingbot.strategy_v2.executors.lp_executor.data_types import LPExecutorCo
 from hummingbot.strategy_v2.executors.lp_executor.lp_executor import LPExecutor
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import CloseType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.logger_mixin_for_test import LoggerMixinForTest
 
 
 def create_mock_remove_event(

--- a/test/hummingbot/strategy_v2/executors/order_executor/test_order_executor.py
+++ b/test/hummingbot/strategy_v2/executors/order_executor/test_order_executor.py
@@ -1,6 +1,4 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.logger_mixin_for_test import LoggerMixinForTest
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from hummingbot.connector.exchange_py_base import ExchangePyBase
@@ -18,6 +16,8 @@ from hummingbot.strategy_v2.executors.order_executor.data_types import (
 from hummingbot.strategy_v2.executors.order_executor.order_executor import OrderExecutor
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import CloseType, TrackedOrder
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.logger_mixin_for_test import LoggerMixinForTest
 
 
 class TestOrderExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):

--- a/test/hummingbot/strategy_v2/executors/position_executor/test_position_executor.py
+++ b/test/hummingbot/strategy_v2/executors/position_executor/test_position_executor.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from hummingbot.connector.exchange_py_base import ExchangePyBase
@@ -15,6 +14,7 @@ from hummingbot.strategy_v2.executors.position_executor.data_types import Positi
 from hummingbot.strategy_v2.executors.position_executor.position_executor import PositionExecutor
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import CloseType, TrackedOrder
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestPositionExecutor(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/strategy_v2/executors/progressive_executor/test_progressive_executor.py
+++ b/test/hummingbot/strategy_v2/executors/progressive_executor/test_progressive_executor.py
@@ -1,6 +1,5 @@
 from decimal import Decimal
 from functools import partial
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from hummingbot.connector.connector_base import ConnectorBase
@@ -25,6 +24,7 @@ from hummingbot.strategy_v2.executors.progressive_executor.data_types import (
 from hummingbot.strategy_v2.executors.progressive_executor.progressive_executor import ProgressiveExecutor
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import CloseType, TrackedOrder
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 
 
 class TestProgressiveExecutor(IsolatedAsyncioWrapperTestCase):

--- a/test/hummingbot/strategy_v2/executors/progressive_executor/test_progressive_executor_integration.py
+++ b/test/hummingbot/strategy_v2/executors/progressive_executor/test_progressive_executor_integration.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from test.hummingbot.strategy_v2.executors.executor_integration_test_base import ExecutorIntegrationTestBase
 
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.strategy_v2.executors.progressive_executor.data_types import (
@@ -10,6 +9,7 @@ from hummingbot.strategy_v2.executors.progressive_executor.data_types import (
 from hummingbot.strategy_v2.executors.progressive_executor.progressive_executor import ProgressiveExecutor
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import CloseType
+from test.hummingbot.strategy_v2.executors.executor_integration_test_base import ExecutorIntegrationTestBase
 
 
 class TestProgressiveExecutorIntegration(ExecutorIntegrationTestBase):

--- a/test/hummingbot/strategy_v2/executors/test_executor_base.py
+++ b/test/hummingbot/strategy_v2/executors/test_executor_base.py
@@ -1,6 +1,4 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.logger_mixin_for_test import LoggerMixinForTest
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from hummingbot.connector.client_order_tracker import ClientOrderTracker
@@ -20,6 +18,8 @@ from hummingbot.strategy_v2.executors.data_types import ExecutorConfigBase
 from hummingbot.strategy_v2.executors.executor_base import ExecutorBase
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import CloseType
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.logger_mixin_for_test import LoggerMixinForTest
 
 
 class TestExecutorBase(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):

--- a/test/hummingbot/strategy_v2/executors/twap_executor/test_twap_executor.py
+++ b/test/hummingbot/strategy_v2/executors/twap_executor/test_twap_executor.py
@@ -1,6 +1,4 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.logger_mixin_for_test import LoggerMixinForTest
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from hummingbot.connector.exchange_py_base import ExchangePyBase
@@ -15,6 +13,8 @@ from hummingbot.strategy_v2.executors.twap_executor.data_types import TWAPExecut
 from hummingbot.strategy_v2.executors.twap_executor.twap_executor import TWAPExecutor
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import CloseType, TrackedOrder
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.logger_mixin_for_test import LoggerMixinForTest
 
 
 class TestTWAPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):

--- a/test/hummingbot/strategy_v2/executors/xemm_executor/test_xemm_executor.py
+++ b/test/hummingbot/strategy_v2/executors/xemm_executor/test_xemm_executor.py
@@ -1,6 +1,4 @@
 from decimal import Decimal
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.logger_mixin_for_test import LoggerMixinForTest
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 from hummingbot.connector.exchange_py_base import ExchangePyBase
@@ -15,6 +13,8 @@ from hummingbot.strategy_v2.executors.xemm_executor.data_types import XEMMExecut
 from hummingbot.strategy_v2.executors.xemm_executor.xemm_executor import XEMMExecutor
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import CloseType, TrackedOrder
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.logger_mixin_for_test import LoggerMixinForTest
 
 
 class TestXEMMExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):

--- a/test/hummingbot/strategy_v2/test_runnable_base.py
+++ b/test/hummingbot/strategy_v2/test_runnable_base.py
@@ -1,9 +1,9 @@
 import asyncio
-from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from test.logger_mixin_for_test import LoggerMixinForTest
 
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.runnable_base import RunnableBase
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from test.logger_mixin_for_test import LoggerMixinForTest
 
 
 class TestRunnableBase(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):

--- a/test/test_isolated_asyncio_wrapper_test_case.py
+++ b/test/test_isolated_asyncio_wrapper_test_case.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import sys
 import threading
 import unittest
+
 from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase, async_to_sync
 
 _PYTEST_RUNNER = "pytest" in sys.modules

--- a/test/test_local_class_event_loop_wrapper_test_case.py
+++ b/test/test_local_class_event_loop_wrapper_test_case.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 import unittest
+
 from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase, LocalClassEventLoopWrapperTestCase
 
 

--- a/test/test_local_test_event_loop_wrapper_test_case.py
+++ b/test/test_local_test_event_loop_wrapper_test_case.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 import unittest
+
 from test.isolated_asyncio_wrapper_test_case import LocalTestEventLoopWrapperTestCase
 
 

--- a/test/test_logger_mixin_for_test.py
+++ b/test/test_logger_mixin_for_test.py
@@ -1,9 +1,9 @@
 import asyncio
 import unittest
 from logging import Logger, LogRecord
-from test.logger_mixin_for_test import LoggerMixinForTest, LogLevel
 
 from hummingbot.logger import HummingbotLogger
+from test.logger_mixin_for_test import LoggerMixinForTest, LogLevel
 
 
 class TestTestLoggerMixin(unittest.TestCase):


### PR DESCRIPTION
Replaces isort (pinned 5.12.0, EOL-adjacent) with ruff's I-rule for import sorting. Eliminates the recurring isort failure on ci-base after _for_bleed promotions widen the development↔ci-base diff scope.

Changes:
- pyproject.toml: add I to [tool.ruff.lint] select, add [tool.ruff.lint.isort] config mirroring previous isort settings, remove [tool.isort] block, remove isort from format pixi task, remove isort from dev deps
- .pre-commit-config.yaml: delete isort hook block

Sweep of existing ci-base Python files found no import-order violations (all files were already isort-compliant). Future violations on _for_bleed branches will be caught by ruff via pre-commit + cron rebuild.

Follows the same pattern as PR #56 but permanently — future isort-style violations will be auto-fixed by ruff via pre-commit + cron rebuild.

## Summary by Sourcery

Replace standalone isort usage with Ruff’s import-sorting rule and align tooling around Ruff for formatting and linting.

Build:
- Remove isort from development dependencies and formatting tasks in pyproject, relying on Ruff for import sorting instead.
- Configure Ruff’s isort settings (including known-first-party modules) to mirror previous isort behavior and extend lint selection to include import-order checks.

CI:
- Remove the isort pre-commit hook so import ordering is enforced solely via Ruff in pre-commit.